### PR TITLE
Ext

### DIFF
--- a/alignment/simple.mk
+++ b/alignment/simple.mk
@@ -49,7 +49,7 @@ sources := $(wildcard algorithms/alignment/*.cpp) \
 		   $(wildcard *.cpp)
 
 ifdef nohdf
-sources := $(filter-out files/% utils/FileOfFileNames.cpp, $(sources))
+sources := $(filter-out files/% utils/FileOfFileNames.cpp format/SAMHeaderPrinter.cpp, $(sources))
 endif
 
 objects := $(sources:.cpp=.o)

--- a/alignment/simple.mk
+++ b/alignment/simple.mk
@@ -1,0 +1,82 @@
+# Requirements:
+#   pbbam
+#   htslib
+#   hdf5
+#   boost
+# Plus relative packages:
+#   pbdata
+#   hdf
+PREFIX?=/usr
+include ../simple.mk
+
+LIBPBDATA_INCLUDE := ../pbdata
+LIBPBIHDF_INCLUDE := ../hdf
+#PBBAM_INCLUDE := $(PBBAM)/include
+#HTSLIB_INCLUDE := $(PBBAM)/third-party/htslib
+
+INCLUDES = -I${PREFIX}/include \
+           -I$(LIBPBDATA_INCLUDE) \
+           -I$(LIBPBIHDF_INCLUDE) \
+	   -I.
+
+#ifneq ($(ZLIB_ROOT), notfound)
+#	INCLUDES += -I$(ZLIB_ROOT)/include
+#endif
+
+#ifeq ($(origin nopbbam), undefined)
+#    INCLUDES += -I$(PBBAM_INCLUDE) -I$(HTSLIB_INCLUDE) -I$(BOOST_INCLUDE)
+#endif
+
+CXXOPTS := -std=c++11 -pedantic -Wno-long-long -MMD -MP
+
+sources := $(wildcard algorithms/alignment/*.cpp) \
+		   $(wildcard algorithms/alignment/sdp/*.cpp) \
+		   $(wildcard algorithms/anchoring/*.cpp) \
+		   $(wildcard algorithms/compare/*.cpp) \
+		   $(wildcard algorithms/sorting/*.cpp) \
+		   $(wildcard datastructures/alignment/*.cpp) \
+		   $(wildcard datastructures/alignmentset/*.cpp) \
+		   $(wildcard datastructures/anchoring/*.cpp) \
+		   $(wildcard datastructures/tuplelists/*.cpp) \
+		   $(wildcard suffixarray/*.cpp) \
+		   $(wildcard qvs/*.cpp) \
+		   $(wildcard statistics/*.cpp) \
+		   $(wildcard tuples/*.cpp) \
+		   $(wildcard utils/*.cpp) \
+		   $(wildcard files/*.cpp) \
+		   $(wildcard format/*.cpp) \
+		   $(wildcard simulator/*.cpp) \
+		   $(wildcard *.cpp)
+
+ifdef nohdf
+sources := $(filter-out files/% utils/FileOfFileNames.cpp, $(sources))
+endif
+
+objects := $(sources:.cpp=.o)
+dependencies := $(sources:.cpp=.d)
+
+all : CXXFLAGS ?= -O3
+
+debug : CXXFLAGS ?= -g -ggdb -fno-inline
+
+profile : CXXFLAGS ?= -Os -pg
+
+g: CXXFLAGS = -g -ggdb -fno-inline -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fno-omit-frame-pointer
+
+all debug profile g: libblasr.a
+
+libblasr.a: $(objects)
+	$(AR_pp) $(ARFLAGS) $@ $^
+
+%.o: %.cpp
+	$(CXX_pp) $(CXXOPTS) $(CXXFLAGS) $(LEGACY) $(INCLUDES) -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.o) $(@:%.o=%.d)" -c $< -o $@
+
+# .INTERMEDIATE: $(objects)
+
+clean:
+	@rm -f libblasr.a
+	@find . -type f -name \*.o -delete
+	@find . -type f -name \*.d -delete
+
+
+-include $(dependencies)

--- a/simple.mk
+++ b/simple.mk
@@ -1,0 +1,16 @@
+SHELL          = bash
+G_BUILDOS_CMD := bash -c 'set -e; set -o pipefail; id=$$(lsb_release -si | tr "[:upper:]" "[:lower:]"); rel=$$(lsb_release -sr); case $$id in ubuntu) printf "$$id-%04d\n" $${rel/./};; centos) echo "$$id-$${rel%%.*}";; *) echo "$$id-$$rel";; esac' 2>/dev/null
+OS_STRING     ?= $(shell $(G_BUILDOS_CMD))
+
+# magic for non-verbose builds
+V ?= 0
+
+CXX_0 = @echo "  CXX	$@"; $(CXX)
+CXX_1 = $(CXX)
+CXX_pp = $(CXX_$(V))
+
+AR_0 = @echo "  AR	$@"; $(AR)
+AR_1 = $(AR)
+AR_pp = $(AR_$(V))
+
+ARFLAGS := rc


### PR DESCRIPTION
By only *adding* some makefiles, I reduce the likelihood that something breaks. Those `simple.mk` files are used (for now) only by the 'github' builds of **pbdagcon**. But I hope we can simplify the regular makefiles soon too.

Within PacBio, I'm not quite sure how folks build these libraries, so I have changed as little as possible. But both **pbdagcon** *and* **blasr_libcpp** can now be built from github source within PacBio, like so:
```sh
p4 describe 153448
cd smrtanalysis/bioinformatics; make -f ext.makefile
```
Try it! That currently uses the `ext` branch of my own (pb-cdunn) forks of these two packages, but we can easily switch to the official PacificBiosciences repos soon.