### PR TITLE
libconfig.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,32 +5,32 @@ SHELL=/bin/bash
 # $Change: 140182 $ 
 
 all:
-	make -C pbdata all
-	make -C hdf all
-	make -C alignment all
+	${MAKE} -C pbdata all
+	${MAKE} -C hdf all
+	${MAKE} -C alignment all
 
 debug:
-	make -C pbdata debug
-	make -C hdf debug
-	make -C alignment debug
+	${MAKE} -C pbdata debug
+	${MAKE} -C hdf debug
+	${MAKE} -C alignment debug
 
 profile:
-	make -C pbdata profile
-	make -C hdf profile
-	make -C alignment profile
+	${MAKE} -C pbdata profile
+	${MAKE} -C hdf profile
+	${MAKE} -C alignment profile
 
 g:
-	make -C pbdata g
-	make -C hdf g
-	make -C alignment g
+	${MAKE} -C pbdata g
+	${MAKE} -C hdf g
+	${MAKE} -C alignment g
 
 gtest:
-	make -C unittest gtest
+	${MAKE} -C unittest gtest
 
 clean:
-	@make -C pbdata clean
-	@make -C hdf clean
-	@make -C alignment clean
-	@make -C unittest clean
+	@${MAKE} -C pbdata clean
+	@${MAKE} -C hdf clean
+	@${MAKE} -C alignment clean
+	@${MAKE} -C unittest clean
 
 cleanall: clean

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Blasr_libcpp is a **library** used by blasr and other executables such as samtoh
 
 
 ##Appendix: Dependencies##
-+ libpbdata
+- libpbdata
    -  does **not** depend on ```libhdf5```
    -  should build without the ```pbbam``` library *for now*
 
@@ -22,3 +22,5 @@ Blasr_libcpp is a **library** used by blasr and other executables such as samtoh
    -  depends on the ```libpbdata``` library to build
    -  can build either with or without the ```libpbhdf``` library
    -  can build either with or without the ```pbbam``` library
+- hts
+   - if you use pbbam, you will need [HTSLib](https://github.com/samtools/htslib)

--- a/alignment/simple.mk
+++ b/alignment/simple.mk
@@ -11,21 +11,11 @@ include ../simple.mk
 
 LIBPBDATA_INCLUDE := ../pbdata
 LIBPBIHDF_INCLUDE := ../hdf
-#PBBAM_INCLUDE := $(PBBAM)/include
-#HTSLIB_INCLUDE := $(PBBAM)/third-party/htslib
 
 INCLUDES = -I${PREFIX}/include \
            -I$(LIBPBDATA_INCLUDE) \
            -I$(LIBPBIHDF_INCLUDE) \
 	   -I.
-
-#ifneq ($(ZLIB_ROOT), notfound)
-#	INCLUDES += -I$(ZLIB_ROOT)/include
-#endif
-
-#ifeq ($(origin nopbbam), undefined)
-#    INCLUDES += -I$(PBBAM_INCLUDE) -I$(HTSLIB_INCLUDE) -I$(BOOST_INCLUDE)
-#endif
 
 CXXOPTS := -std=c++11 -pedantic -Wno-long-long -MMD -MP
 

--- a/pbdata/Makefile
+++ b/pbdata/Makefile
@@ -56,13 +56,15 @@ g: CXXFLAGS = -g -ggdb -fno-inline -fno-builtin-malloc -fno-builtin-calloc -fno-
 
 all debug profile g: mklibconfig $(TARGET_LIB)
 
-mklibconfig:
 ifeq ($(origin nopbbam), undefined)
-	@grep "USE_PBBAM" libconfig.h 2>/dev/null 1>/dev/null || echo "#define USE_PBBAM" > libconfig.h
     INCLUDES += -I$(PBBAM_INCLUDE) -I$(HTSLIB_INCLUDE) -I$(BOOST_INCLUDE)
+    USE_PBBAM:=YES
 else
-	@rm -f libconfig.h && echo "" > libconfig.h && echo "no use libpbbam"
+    USE_PBBAM:=NO
 endif
+
+mklibconfig:
+	./mklibconfig.sh libconfig.h ${USE_PBBAM}
 
 libpbdata.a: $(objects)
 	$(AR_pp) $(ARFLAGS) $@ $^

--- a/pbdata/mklibconfig.sh
+++ b/pbdata/mklibconfig.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+fn=$1
+use_pbbam=$2
+# If $fn exists, then guarantee its contents are correct.
+# If not, write the proper contents.
+# This way, 'make' will not have to re-create a perfectly fine file,
+# which would cause all other targets to be remade.
+
+use0=$(cat <<'EOF'
+EOF
+)
+
+use1=$(cat <<'EOF'
+#define USE_PBBAM
+EOF
+)
+
+if [ "${use_pbbam}" == "YES" ]; then
+    wanted=$use1
+else
+    wanted=$use0
+fi
+
+if [ -r $fn ]; then
+    actual=$(<"${fn}")
+else
+    actual="EMPTY"
+fi
+
+if [ "$wanted" != "$actual" ]; then
+    echo "$wanted" > $fn
+fi


### PR DESCRIPTION
Re-creating this file would cause make to redo things repeatedly.

Make is timestamp-based. A more sophisticated build system would use checksums and would include the full build rules, but that's hard. This is a fair compromise to help make do what make does best.