### PR TITLE
copy libconfig.h into build directory

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,6 +9,7 @@ all:
 	${MAKE} libpbihdf
 	${MAKE} libblasr
 libpbdata:
+	${MAKE} -C ${THISDIR}/pbdata libconfig.h
 	${MAKE} -C ${THISDIR}/pbdata all
 libpbihdf:
 	${MAKE} -C ${THISDIR}/hdf all

--- a/pbdata/makefile
+++ b/pbdata/makefile
@@ -27,6 +27,9 @@ libpbdata.a: $(objects)
 
 libpbdata${SH_LIB_EXT}: $(shared_objects)
 
+libconfig.h:
+	cp -af ${LIBCONFIG_H} $@
+
 clean: 
 	rm -f libpbdata.a  libpbdata.so *.o *.d
 


### PR DESCRIPTION
The complexity here is because we sometimes build the
subdirs separately, and sometimes together. So we don't
know whether configure.py is run 3 times in 3 dirs, or just
once. So we don't know in advance where to put libconfig.h.

A better solution might be an 'install' rule. Soon.