### PR TITLE
Fix outputdir

### DIFF
--- a/hdf/makefile
+++ b/hdf/makefile
@@ -14,6 +14,7 @@ all: libpbihdf.a libpbihdf${SH_LIB_EXT}
 
 paths := ${THISDIR}
 sources := $(wildcard ${THISDIR}*.cpp)
+sources := $(notdir ${sources})
 objects := $(sources:.cpp=.o)
 shared_objects := $(sources:.cpp=.shared.o)
 dependencies := $(objects:.o=.d) $(shared_objects:.o=.d)


### PR DESCRIPTION
vpath works correctly only when the source filenames do not include directories.

re: PacificBiosciences/pith#6
@mjhsieh, With this change, your 'make clean' is no longer needed, but it doesn't hurt.