### PR TITLE
bam_concordant

### DIFF
--- a/alignment/format/BAMPrinter.hpp
+++ b/alignment/format/BAMPrinter.hpp
@@ -8,13 +8,23 @@
 #include "pbbam/BamHeader.h"
 #include "pbbam/BamWriter.h"
 
+namespace BAMOutput {
+
+template<typename T_Sequence>
+void SetAlignedSequence(T_AlignmentCandidate &alignment, T_Sequence &read,
+        T_Sequence &alignedSeq);
+
+template<typename T_Sequence>
+void CreateCIGARString(T_AlignmentCandidate &alignment,
+        T_Sequence &read, std::string &cigarString, const bool cigarUseSeqMatch);
+
 template<typename T_Sequence>
 void AlignmentToBamRecord(T_AlignmentCandidate & alignment, 
         T_Sequence & read, PacBio::BAM::BamRecord & bamRecord, 
         AlignmentContext & context, SupplementalQVList & qvList,
         Clipping clipping, bool cigarUseSeqMatch);
 
-namespace BAMOutput {
+
 
 template<typename T_Sequence>
 void PrintAlignment(T_AlignmentCandidate &alignment, T_Sequence &read,
@@ -22,6 +32,7 @@ void PrintAlignment(T_AlignmentCandidate &alignment, T_Sequence &read,
         SupplementalQVList & qvList, Clipping clipping, 
         bool cigarUseSeqMatch=false);
 }
+
 
 #include "BAMPrinterImpl.hpp"
 

--- a/pbdata/SMRTSequence.cpp
+++ b/pbdata/SMRTSequence.cpp
@@ -236,7 +236,8 @@ void SMRTSequence::Free() {
     // Reset member variables
     subreadStart_ = subreadEnd_ = 0;
     lowQualityPrefix = lowQualitySuffix = 0;
-    readScore = highQualityRegionScore = 0;
+    readScore = 0;
+    highQualityRegionScore = 0;
     readGroupId_ = "";
     copiedFromBam = false;
 #ifdef USE_PBBAM


### PR DESCRIPTION
Here is the full *bam_concordant* branch. The code at the tip is identical to ylipacbio/blasr_libcpp@598b674 (aside from whitespace changes), which is the tip of *bam_concordant*.

EDIT: The unittests passed after a clean rebuild. Something is wrong with the dependencies. (Maybe the unittest dir is missing a make-depend.)