### PR TITLE
Array delete bug

### DIFF
--- a/pbdata/FASTAReader.cpp
+++ b/pbdata/FASTAReader.cpp
@@ -217,7 +217,7 @@ void FASTAReader::ReadTitle(long &p, FASTASequence & seq) {
     int seqTitleLen; 
     ReadTitle(p, seqTitle, seqTitleLen);
     seq.CopyTitle(seqTitle, seqTitleLen);
-    if (seqTitle) {delete seqTitle;}
+    if (seqTitle) {delete [] seqTitle;}
 }
 
 void FASTAReader::ReadTitle(long &p, char *&title, int &titleLength) {

--- a/unittest/pbdata/DNASequence_gtest.cpp
+++ b/unittest/pbdata/DNASequence_gtest.cpp
@@ -257,7 +257,7 @@ TEST_F(DNASequenceTest, ReferenceSubstring) {
     EXPECT_FALSE(dnaTwo.deleteOnExit);
 
 //    EXPECT_DEATH_IF_SUPPORTED(dnaTwo.ReferenceSubstring(dnaOne, 100), "");
-    delete dnaOne.seq;
+    delete [] dnaOne.seq;
 }
 /*
 TEST_F(DNASequenceTest, CopyFromString) {


### PR DESCRIPTION
This bug predates any of yli's recent changes. E.g. @963859fcca47feaec7c47523157cf1c2888bad69, used in PacificBiosciences/blasr@2551ead:
```
==126360== Mismatched free() / delete / delete []
==126360==    at 0x4C2C0F1: operator delete(void*) (vg_replace_malloc.c:507)
==126360==    by 0x5643626: FASTAReader::ReadTitle(long&, FASTASequence&) (FASTAReader.cpp:220)
==126360==    by 0x564384F: FASTAReader::GetNext(FASTASequence&) (FASTAReader.cpp:268)
==126360==    by 0x51B1823: ReaderAgglomerate::GetNext(CCSSequence&) (ReaderAgglomerate.cpp:420)
==126360==    by 0x4133BC: main (in /home/UNIXHOME/cdunn/repo/gh/blasr/utils/toAfg)
==126360==  Address 0x78818c0 is 0 bytes inside a block of size 6 alloc'd
==126360==    at 0x4C2B76A: operator new[](unsigned long) (vg_replace_malloc.c:389)
==126360==    by 0x5643712: FASTAReader::ReadTitle(long&, char*&, int&) (FASTAReader.cpp:236)
==126360==    by 0x56435FB: FASTAReader::ReadTitle(long&, FASTASequence&) (FASTAReader.cpp:218)
==126360==    by 0x564384F: FASTAReader::GetNext(FASTASequence&) (FASTAReader.cpp:268)
==126360==    by 0x51B1823: ReaderAgglomerate::GetNext(CCSSequence&) (ReaderAgglomerate.cpp:420)
==126360==    by 0x4133BC: main (in /home/UNIXHOME/cdunn/repo/gh/blasr/utils/toAfg)
```
Allocation is via `operator new[]`, but deletion neglects the `[]`.

This bug has existed since March. Has no-one ever run valgrind on blasr?