### PR TITLE
More changes

### DIFF
--- a/alignment/files/ReaderAgglomerate.hpp
+++ b/alignment/files/ReaderAgglomerate.hpp
@@ -19,7 +19,7 @@
 #ifdef USE_PBBAM
 #include "pbbam/BamFile.h"
 #include "pbbam/EntireFileQuery.h"
-#include "pbbam/GroupQuery.h"
+#include "pbbam/QNameQuery.h"
 #include "pbbam/BamRecord.h"
 #endif
 

--- a/hdf/HDFRegionTableReader.hpp
+++ b/hdf/HDFRegionTableReader.hpp
@@ -28,14 +28,14 @@ private:
 
     bool isInitialized_; // whether or not this reader is initialized.
 
-    bool fileContainsRegionTable;
-
     int nRows;
+
+    bool fileContainsRegionTable;
 
 public:
 
     HDFRegionTableReader(void)
-    : curRow(0), nRows(0), isInitialized_(false)
+    : curRow(0), isInitialized_(false), nRows(0) 
     , fileContainsRegionTable(false) {}
 
     int Initialize(std::string &regionTableFileName, 

--- a/pbdata/CCSSequence.hpp
+++ b/pbdata/CCSSequence.hpp
@@ -10,11 +10,6 @@
 // A CCS Sequence is both a SMRTSequence itself, and contains a list of SMRTSequences.
 //
 class CCSSequence : public SMRTSequence {
-private:
-    void UNDEFINED(const std::string & msg) const {
-        std::cout << msg  << " is not defined in CCSSequence." << std::endl; exit(1);
-    }
-
 public:
 	UInt numPasses;
 	UInt numConsensusBases;
@@ -36,12 +31,6 @@ public:
     UInt HoleNumber(void) const;
 
     CCSSequence & HoleNumber(const UInt holeNumber);
-
-    DNALength SubreadStart(void) const {UNDEFINED("SubreadStart");}
-
-    DNALength SubreadEnd(void) const {UNDEFINED("SubreadEnd");}
-
-    DNALength SubreadLength(void) const {UNDEFINED("SubreadLength");}
 
 	int GetStorageSize(); 
 


### PR DESCRIPTION
Revert changes to CCSSequence function SubreadStart, SubreadEnd, SubreadLength.
ReaderAgglomerate.hpp: update pbbam header file because pbbam has been refactored in p4 CL 163004
HDFRegionTableReader: removed a warning
