### PR TITLE
Add SequentialZmwGroupQuery and PbiFilterZmwGroupQuery

### DIFF
--- a/alignment/makefile
+++ b/alignment/makefile
@@ -20,7 +20,8 @@ all: libblasr.a libblasr${SH_LIB_EXT}
 
 paths := . simulator format files utils tuples statistics qvs suffixarray \
 	datastructures/alignment datastructures/alignmentset datastructures/anchoring datastructures/tuplelists \
-	algorithms/alignment algorithms/alignment/sdp algorithms/anchoring algorithms/compare algorithms/sorting
+	algorithms/alignment algorithms/alignment/sdp algorithms/anchoring algorithms/compare algorithms/sorting \
+	query
 paths := $(patsubst %,${THISDIR}%,${paths})
 sources := $(shell find ${THISDIR} -name '*.cpp')
 

--- a/alignment/query/PbiFilterZmwGroupQuery.cpp
+++ b/alignment/query/PbiFilterZmwGroupQuery.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2014-2015, Pacific Biosciences of California, Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted (subject to the limitations in the
+// disclaimer below) provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//  * Neither the name of Pacific Biosciences nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+// GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY PACIFIC
+// BIOSCIENCES AND ITS CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL PACIFIC BIOSCIENCES OR ITS
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+// USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+// Author: Yuan Li
+#ifdef USE_PBBAM
+#include "pbbam/PbiFilterZmwGroupQuery.h"
+#include "CompositeBamReader.h"
+#include <boost/optional.hpp>
+#include <cassert>
+using namespace PacBio;
+using namespace PacBio::BAM;
+using namespace PacBio::BAM::internal;
+using namespace std;
+
+struct PbiFilterZmwGroupQuery::PbiFilterZmwGroupQueryPrivate
+{
+    /// TODO: To ensure that BamRecords of a zmw are always stored 
+    /// sequentially in bam files, such as in movie.subreads.bam.
+public:
+    PbiFilterZmwGroupQueryPrivate(const PbiFilter& filter, const DataSet& dataset)
+        : reader_(new internal::PbiFilterCompositeBamReader<Compare::None>(filter, dataset))
+        , nextRecord_(boost::none)
+    { }
+
+    bool GetNext(vector<BamRecord>& records)
+    {
+        records.clear();
+
+        string movieName;
+        uint32_t holeNumber;
+
+        if (nextRecord_.is_initialized()) {
+            BamRecord r = nextRecord_.get();
+            movieName = r.MovieName();
+            holeNumber = r.HoleNumber();
+            records.push_back(std::move(r));
+            nextRecord_ = boost::none;
+        }
+
+        BamRecord record;
+        while (reader_->GetNext(record)) {
+            if (records.empty()) {
+                movieName = record.MovieName();
+                holeNumber = record.HoleNumber();
+                records.push_back(record);
+            }
+            else {
+                assert(!records.empty());
+                if (record.MovieName() == movieName and record.HoleNumber() == holeNumber)
+                    records.push_back(record);
+                else {
+                    nextRecord_ = record;
+                    return true;
+                }
+            }
+        }
+        return !records.empty();
+    }
+
+public:
+    unique_ptr<internal::PbiFilterCompositeBamReader<Compare::None>> reader_;
+
+    boost::optional<BamRecord> nextRecord_;
+};
+
+PbiFilterZmwGroupQuery::PbiFilterZmwGroupQuery(const DataSet& dataset)
+    : internal::IGroupQuery()
+    , d_(new PbiFilterZmwGroupQueryPrivate(  (dataset.Filters().Size() == 0) 
+                                           ? (PbiFilter{PbiQueryLengthFilter{ 0 , Compare::GREATER_THAN } })
+                                           : (PbiFilter::FromDataSet(dataset))
+                                           , dataset))
+{ }
+
+PbiFilterZmwGroupQuery::PbiFilterZmwGroupQuery(const PbiFilter& filter, const DataSet& dataset)
+    : internal::IGroupQuery()
+    , d_(new PbiFilterZmwGroupQueryPrivate(filter, dataset))
+{ }
+
+PbiFilterZmwGroupQuery::~PbiFilterZmwGroupQuery(void) { }
+
+bool PbiFilterZmwGroupQuery::GetNext(vector<BamRecord>& records)
+{ return d_->GetNext(records); }
+#endif

--- a/alignment/query/PbiFilterZmwGroupQuery.h
+++ b/alignment/query/PbiFilterZmwGroupQuery.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2014-2015, Pacific Biosciences of California, Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted (subject to the limitations in the
+// disclaimer below) provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//  * Neither the name of Pacific Biosciences nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+// GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY PACIFIC
+// BIOSCIENCES AND ITS CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL PACIFIC BIOSCIENCES OR ITS
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+// USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+// Author: Yuan Li
+#ifdef USE_PBBAM
+#ifndef PBIFILTER_ZMWGROUPQUERY_H 
+#define PBIFILTER_ZMWGROUPQUERY_H
+
+#include "pbbam/internal/QueryBase.h"
+#include "pbbam/PbiFilter.h"
+#include <memory>
+
+namespace PacBio {
+namespace BAM {
+
+/// This class operates on a name-sorted BAM file, with each iteration of the query
+/// returning each contiguous block of records that share a name.
+///
+/// \note Iterate over zmws, return vector of subreads of a zmw each time.
+///
+class PBBAM_EXPORT PbiFilterZmwGroupQuery : public internal::IGroupQuery
+{
+public:
+    PbiFilterZmwGroupQuery(const DataSet& dataset);
+    PbiFilterZmwGroupQuery(const PbiFilter& filter, const DataSet& dataset);
+    ~PbiFilterZmwGroupQuery(void);
+
+public:
+    bool GetNext(std::vector<BamRecord>& records);
+
+private:
+    struct PbiFilterZmwGroupQueryPrivate;
+    std::unique_ptr<PbiFilterZmwGroupQueryPrivate> d_;
+};
+
+} // namespace BAM
+} // namespace PacBio
+
+#endif // PBIFILTER_ZMWGROUPQUERY_H
+#endif

--- a/alignment/query/SequentialZmwGroupQuery.cpp
+++ b/alignment/query/SequentialZmwGroupQuery.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2014-2015, Pacific Biosciences of California, Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted (subject to the limitations in the
+// disclaimer below) provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//  * Neither the name of Pacific Biosciences nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+// GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY PACIFIC
+// BIOSCIENCES AND ITS CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL PACIFIC BIOSCIENCES OR ITS
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+// USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+// Author: Yuan Li
+
+#ifdef USE_PBBAM
+#include "pbbam/SequentialZmwGroupQuery.h"
+#include "CompositeBamReader.h"
+#include <boost/optional.hpp>
+#include <cassert>
+using namespace PacBio;
+using namespace PacBio::BAM;
+using namespace PacBio::BAM::internal;
+using namespace std;
+
+struct SequentialZmwGroupQuery::SequentialZmwGroupQueryPrivate
+{
+public:
+    SequentialZmwGroupQueryPrivate(const DataSet& dataset)
+        : reader_(new SequentialCompositeBamReader(dataset))
+        , nextRecord_(boost::none)
+    { }
+
+    bool GetNext(vector<BamRecord>& records)
+    {
+        records.clear();
+
+        string movieName;
+        uint32_t holeNumber;
+
+        if (nextRecord_.is_initialized()) {
+            BamRecord r = nextRecord_.get();
+            movieName = r.MovieName();
+            holeNumber = r.HoleNumber();
+            records.push_back(std::move(r));
+            nextRecord_ = boost::none;
+        }
+
+        BamRecord record;
+        while (reader_->GetNext(record)) {
+            if (records.empty()) {
+                movieName = record.MovieName();
+                holeNumber = record.HoleNumber();
+                records.push_back(record);
+            }
+            else {
+                assert(!records.empty());
+                if (record.MovieName() == movieName and record.HoleNumber() == holeNumber)
+                    records.push_back(record);
+                else {
+                    nextRecord_ = record;
+                    return true;
+                }
+            }
+        }
+        return !records.empty();
+    }
+
+public:
+    unique_ptr<SequentialCompositeBamReader> reader_;
+
+    boost::optional<BamRecord> nextRecord_;
+};
+
+SequentialZmwGroupQuery::SequentialZmwGroupQuery(const DataSet& dataset)
+    : internal::IGroupQuery()
+    , d_(new SequentialZmwGroupQueryPrivate(dataset))
+{ }
+
+SequentialZmwGroupQuery::~SequentialZmwGroupQuery(void) { }
+
+bool SequentialZmwGroupQuery::GetNext(vector<BamRecord>& records)
+{ return d_->GetNext(records); }
+
+#endif

--- a/alignment/query/SequentialZmwGroupQuery.h
+++ b/alignment/query/SequentialZmwGroupQuery.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2014-2015, Pacific Biosciences of California, Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted (subject to the limitations in the
+// disclaimer below) provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//  * Neither the name of Pacific Biosciences nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+// GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY PACIFIC
+// BIOSCIENCES AND ITS CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL PACIFIC BIOSCIENCES OR ITS
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+// USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+
+// Author: Yuan Li
+#ifdef USE_PBBAM
+#ifndef SEQUENTIAL_ZMWGROUPQUERY_H
+#define SEQUENTIAL_ZMWGROUPQUERY_H
+
+#include "pbbam/internal/QueryBase.h"
+#include <memory>
+
+namespace PacBio {
+namespace BAM {
+
+/// This class operates on a name-sorted BAM file, with each iteration of the query
+/// returning each contiguous block of records that share a name.
+///
+/// \note Iterate over zmws, return vector of subreads of a zmw each time.
+///
+class PBBAM_EXPORT SequentialZmwGroupQuery : public internal::IGroupQuery
+{
+public:
+    SequentialZmwGroupQuery(const DataSet& dataset);
+    ~SequentialZmwGroupQuery(void);
+
+public:
+    bool GetNext(std::vector<BamRecord>& records);
+
+private:
+    struct SequentialZmwGroupQueryPrivate;
+    std::unique_ptr<SequentialZmwGroupQueryPrivate> d_;
+};
+
+} // namespace BAM
+} // namespace PacBio
+
+#endif // SEQUENTIAL_ZMWGROUPQUERY_H
+#endif


### PR DESCRIPTION
Moved  bug 28882 p4 CL 164057 to blasr_libcpp.

    SequentialZmwGroupQuery returns a vector of bam records of a zmw at a time.

    PbiFilterZmwGroupQuery returns a vector of bam records of a zmw at a time and respects filters in dataset.

Note that both classes require bam records of a zmw to be stored next to one another.
Note that we will switch to Derek's pbbam APIs when they are available.