### PR TITLE
Cigar string, allow adjacent indels ON|OFF.

### DIFF
--- a/alignment/format/BAMPrinter.hpp
+++ b/alignment/format/BAMPrinter.hpp
@@ -13,7 +13,8 @@ void AlignmentToBamRecord(T_AlignmentCandidate & alignment,
         T_Sequence & read, T_Sequence & subread, 
         PacBio::BAM::BamRecord & bamRecord, 
         AlignmentContext & context, SupplementalQVList & qvList,
-        Clipping clipping, bool cigarUseSeqMatch);
+        Clipping clipping,
+        bool cigarUseSeqMatch=false, const bool allowAdjacentIndels=true);
 
 namespace BAMOutput {
 
@@ -22,7 +23,7 @@ void PrintAlignment(T_AlignmentCandidate &alignment, T_Sequence &read,
         T_Sequence & subread,
         PacBio::BAM::BamWriter &bamWriter, AlignmentContext &context, 
         SupplementalQVList & qvList, Clipping clipping, 
-        bool cigarUseSeqMatch=false);
+        bool cigarUseSeqMatch=false, const bool allowAdjacentIndels=true);
 }
 
 #include "BAMPrinterImpl.hpp"

--- a/alignment/format/BAMPrinterImpl.hpp
+++ b/alignment/format/BAMPrinterImpl.hpp
@@ -14,7 +14,7 @@ template<typename T_Sequence>
 void AlignmentToBamRecord(T_AlignmentCandidate & alignment, 
         T_Sequence & read, T_Sequence & subread, PacBio::BAM::BamRecord & bamRecord,
         AlignmentContext & context, SupplementalQVList & qvList,
-        Clipping clipping, bool cigarUseSeqMatch) {
+        Clipping clipping, bool cigarUseSeqMatch, const bool allowAdjacentIndels) {
     assert(clipping == SAMOutput::soft or clipping == SAMOutput::subread);
 
     // Build from scratch if input reads are not from pbbam files.
@@ -38,7 +38,7 @@ void AlignmentToBamRecord(T_AlignmentCandidate & alignment,
     CreateCIGARString(alignment, read, cigarString, clipping,
                       prefixSoftClip, suffixSoftClip, 
                       prefixHardClip, suffixHardClip,
-                      cigarUseSeqMatch);
+                      cigarUseSeqMatch, allowAdjacentIndels);
     SetAlignedSequence(alignment, read, alignedSequence, clipping);
     PacBio::BAM::Cigar cigar = PacBio::BAM::Cigar::FromStdString(cigarString);
  
@@ -157,10 +157,11 @@ void AlignmentToBamRecord(T_AlignmentCandidate & alignment,
 template<typename T_Sequence>
 void BAMOutput::PrintAlignment(T_AlignmentCandidate &alignment, T_Sequence &read, T_Sequence & subread,
         PacBio::BAM::BamWriter &bamWriter, AlignmentContext &context, 
-        SupplementalQVList & qvList, Clipping clipping, bool cigarUseSeqMatch) {
+        SupplementalQVList & qvList, Clipping clipping,
+        bool cigarUseSeqMatch, const bool allowAdjacentIndels) {
 
     PacBio::BAM::BamRecord bamRecord;
-    AlignmentToBamRecord(alignment, read, subread, bamRecord, context, qvList, clipping, cigarUseSeqMatch);
+    AlignmentToBamRecord(alignment, read, subread, bamRecord, context, qvList, clipping, cigarUseSeqMatch, allowAdjacentIndels);
     bamWriter.Write(bamRecord);
 }
 #endif

--- a/alignment/format/SAMPrinter.cpp
+++ b/alignment/format/SAMPrinter.cpp
@@ -99,8 +99,43 @@ void SAMOutput::AddMatchBlockCigarOps(DNASequence & qSeq, DNASequence & tSeq,
     }
 }
 
+void SAMOutput::MergeAdjacentIndels(std::vector<int> &opSize, 
+                                    std::vector<char> &opChar,
+                                    const char mismatchChar) {
+    assert(opSize.size() == opChar.size());
+    int i, j;
+    for (i = 0, j = 1; i < opSize.size() and j < opSize.size(); j++) {
+        const int  ni = opSize[i], nj = opSize[j];
+        const char ci = opChar[i], cj = opChar[j];
+        if (ci == cj) {
+            opSize[i] = ni + nj; // merge i and j to i
+        } else {
+            if ((ci == 'I' and cj == 'D') or (ci == 'D' and cj == 'I')) {
+                opSize[i] = std::min(ni, nj);
+                opChar[i] = mismatchChar; // merge 'I' and 'D' to Mismatch
+                if (i != 0 and i != opSize.size() and opChar[i] == opChar[i - 1]) {
+                    opSize[i - 1] += opSize[i]; // merge with i - 1?
+                    i--;
+                }
+                if (ni != nj) {
+                    i++; // the remaining 'I' or 'D'
+                    opSize[i] = std::abs(ni - nj);
+                    opChar[i] = (ni > nj) ? ci: cj;
+                }
+            } else  {
+                i++; // move forward.
+                opSize[i] = nj;
+                opChar[i] = cj;
+            }
+        }
+    }
+    opSize.erase(opSize.begin() + i + 1, opSize.end());
+    opChar.erase(opChar.begin() + i + 1, opChar.end());
+}
+
 void SAMOutput::CreateNoClippingCigarOps(T_AlignmentCandidate &alignment, 
-        std::vector<int> &opSize, std::vector<char> &opChar, bool cigarUseSeqMatch) {
+        std::vector<int> &opSize, std::vector<char> &opChar,
+        bool cigarUseSeqMatch, const bool allowAdjacentIndels) {
     //
     // Create the cigar string for the aligned region of a read,
     // excluding the clipping.
@@ -173,6 +208,10 @@ void SAMOutput::CreateNoClippingCigarOps(T_AlignmentCandidate &alignment,
     if (alignment.tStrand == 1) {
         std::reverse(opSize.begin(), opSize.end());
         std::reverse(opChar.begin(), opChar.end());
+    }
+
+    if (not allowAdjacentIndels) {
+        MergeAdjacentIndels(opSize, opChar, (cigarUseSeqMatch?'X':'M'));
     }
 }
 

--- a/alignment/format/SAMPrinter.hpp
+++ b/alignment/format/SAMPrinter.hpp
@@ -37,18 +37,23 @@ void CreateDNAString(DNASequence &seq, DNASequence &clippedSeq,
     int trimFront=0, int trimEnd=0); 
 
 void AddGaps(T_AlignmentCandidate &alignment, int gapIndex,
-        std::vector<int> &opSize, std::vector<char> &opChar); 
+        std::vector<int> &opSize, std::vector<char> &opChar);
 
 // Add sequence match/mismatch CIGAR string Ops for block b.
 void AddMatchBlockCigarOps(DNASequence & qSeq, DNASequence & tSeq, blasr::Block & b,
         DNALength & qSeqPos, DNALength & tSeqPos,
         std::vector<int> & opSize, std::vector<char> & opChar);
 
+// Merge adjacent indels and mismatches.
+void MergeAdjacentIndels(std::vector<int> &opSize, std::vector<char> &opChar,
+                         const char mismatchChar);
+
 // If cigarUseSeqMatch is true, cigar string uses '=' and 'X' 
 // instead of 'M' to represent sequence match and mismatch;
 void CreateNoClippingCigarOps(T_AlignmentCandidate &alignment, 
         std::vector<int> &opSize, std::vector<char> &opChar,
-        bool cigarUseSeqMatch = false); 
+        bool cigarUseSeqMatch = false, 
+        const bool allowAdjacentIndels = true); 
 //
 // 
 // The aligned sequence is either the sequence from the first
@@ -80,13 +85,15 @@ void CreateCIGARString(T_AlignmentCandidate &alignment, T_Sequence &read,
         std::string &cigarString, Clipping clipping, 
         DNALength &prefixSoftClip, DNALength &suffixSoftClip,
         DNALength &prefixHardClip, DNALength &suffixHardClip,
-        bool cigarUseSeqMatch = false); 
+        bool cigarUseSeqMatch = false,
+        const bool allowAdjacentIndels = true); 
 
 template<typename T_Sequence>
 void PrintAlignment(T_AlignmentCandidate &alignment, T_Sequence &read,
         std::ostream &samFile, AlignmentContext &context, 
         SupplementalQVList & qvList, Clipping clipping = none,
-        bool cigarUseSeqMatch = false); 
+        bool cigarUseSeqMatch = false,
+        const bool allowAdjacentIndels = true); 
 }
 
 #include "SAMPrinterImpl.hpp"

--- a/alignment/format/SAMPrinterImpl.hpp
+++ b/alignment/format/SAMPrinterImpl.hpp
@@ -97,13 +97,13 @@ void SAMOutput::CreateCIGARString(T_AlignmentCandidate &alignment,
         Clipping clipping,
         DNALength & prefixSoftClip, DNALength & suffixSoftClip, 
         DNALength & prefixHardClip, DNALength & suffixHardClip,
-        bool cigarUseSeqMatch) {
+        bool cigarUseSeqMatch, const bool allowAdjacentIndels) {
 
     cigarString = "";
     // All cigarString use the no clipping core
     std::vector<int> opSize;
     std::vector<char> opChar;
-    CreateNoClippingCigarOps(alignment, opSize, opChar, cigarUseSeqMatch);
+    CreateNoClippingCigarOps(alignment, opSize, opChar, cigarUseSeqMatch, allowAdjacentIndels);
 
     // Clipping needs to be added
 
@@ -178,7 +178,8 @@ void SAMOutput::PrintAlignment(T_AlignmentCandidate &alignment,
         AlignmentContext &context,
         SupplementalQVList & qvList,
         Clipping clipping,
-        bool cigarUseSeqMatch) {
+        bool cigarUseSeqMatch,
+        const bool allowAdjacentIndels) {
 
     std::string cigarString;
     uint16_t flag;
@@ -186,7 +187,7 @@ void SAMOutput::PrintAlignment(T_AlignmentCandidate &alignment,
     DNALength prefixSoftClip = 0, suffixSoftClip = 0;
     DNALength prefixHardClip = 0, suffixHardClip = 0;
 
-    CreateCIGARString(alignment, read, cigarString, clipping, prefixSoftClip, suffixSoftClip, prefixHardClip, suffixHardClip, cigarUseSeqMatch);
+    CreateCIGARString(alignment, read, cigarString, clipping, prefixSoftClip, suffixSoftClip, prefixHardClip, suffixHardClip, cigarUseSeqMatch, allowAdjacentIndels);
     SetAlignedSequence(alignment, read, alignedSequence, clipping);
     BuildFlag(alignment, context, flag);
     samFile << alignment.qName << "\t" 

--- a/unittest/alignment/format/SAMPrinter_gtest.cpp
+++ b/unittest/alignment/format/SAMPrinter_gtest.cpp
@@ -35,11 +35,51 @@ TEST(SAMPrinterTest, AddMatchBlockCigarOps) {
     vector<int> opSize;
     vector<char> opChar;
 
+    DNALength qSeqPos = 0;
+    DNALength tSeqPos = 0;
+
     const vector<int>  expOpSize = {5  , 1  , 9  };
     const vector<char> expOpChar = {'=', 'X', '='};
 
-    AddMatchBlockCigarOps(qSeq, tSeq, b, opSize, opChar);
+    AddMatchBlockCigarOps(qSeq, tSeq, b, qSeqPos, tSeqPos, opSize, opChar);
 
     EXPECT_EQ(opSize, expOpSize);
     EXPECT_EQ(opChar, expOpChar);
+}
+
+std::string merge_indels(const std::vector<int>& opSize, 
+                         const std::vector<char> & opChar) {
+    std::vector<int> opSize_ = opSize;
+    std::vector<char> opChar_ = opChar;
+    SAMOutput::MergeAdjacentIndels(opSize_, opChar_, 'X');
+    std::string ret = "";
+    SAMOutput::CigarOpsToString(opSize_, opChar_, ret);
+    return ret;
+}
+
+TEST(SAMPrinterTest, MergeAdjacentIndels) {
+    std::vector<int>  opSize({10,  1,   5,   7,  6});
+    std::vector<char> opChar({'=', '=', '=', 'X', 'X'});
+
+    EXPECT_EQ(merge_indels(opSize, opChar), "16=13X");
+
+    opChar = std::vector<char>({'I', 'D', 'D', '=', 'I'});
+    EXPECT_EQ(merge_indels(opSize, opChar), "6X4I7=6I");
+
+    opChar = std::vector<char>({'I', 'D', 'D', 'I', 'I'});
+    EXPECT_EQ(merge_indels(opSize, opChar), "6X17I");
+
+    opChar = std::vector<char>({'=', 'D', 'D', 'I', 'I'});
+    EXPECT_EQ(merge_indels(opSize, opChar), "10=6X7I");
+
+    opChar = std::vector<char>({'I', 'D', '=', 'I', 'D'});
+    EXPECT_EQ(merge_indels(opSize, opChar), "1X9I5=6X1I");
+
+    opSize = std::vector<int >({1,  1 });
+    opChar = std::vector<char>({'I','D'});
+    EXPECT_EQ(merge_indels(opSize, opChar), "1X");
+
+    opSize = std::vector<int >({1,  10 });
+    opChar = std::vector<char>({'I','D'});
+    EXPECT_EQ(merge_indels(opSize, opChar), "1X9D");
 }

--- a/unittest/alignment/format/SAMPrinter_gtest.cpp
+++ b/unittest/alignment/format/SAMPrinter_gtest.cpp
@@ -82,4 +82,20 @@ TEST(SAMPrinterTest, MergeAdjacentIndels) {
     opSize = std::vector<int >({1,  10 });
     opChar = std::vector<char>({'I','D'});
     EXPECT_EQ(merge_indels(opSize, opChar), "1X9D");
+
+    opSize = std::vector<int >({1  });
+    opChar = std::vector<char>({'='});
+    EXPECT_EQ(merge_indels(opSize, opChar), "1=");
+
+    opSize = std::vector<int >({1  });
+    opChar = std::vector<char>({'I'});
+    EXPECT_EQ(merge_indels(opSize, opChar), "1I");
+
+    opSize = std::vector<int >({1  , 10});
+    opChar = std::vector<char>({'X', '='});
+    EXPECT_EQ(merge_indels(opSize, opChar), "1X10=");
+
+    opSize = std::vector<int >({1  , 10});
+    opChar = std::vector<char>({'I', '='});
+    EXPECT_EQ(merge_indels(opSize, opChar), "1I10=");
 }

--- a/unittest/makefile
+++ b/unittest/makefile
@@ -11,7 +11,6 @@ space := $(null) $(null)
 
 broken_test_sources := \
 	${SRCDIR}/alignment/format/SAMHeaderPrinter_gtest.cpp \
-	${SRCDIR}/alignment/format/SAMPrinter_gtest.cpp \
 	$(null)
 
 


### PR DESCRIPTION
Added a function which merges adjacent indels in CIGAR when called.
Fixed a broken unittest.

We may or may not need to merge this pull request, depending on whether or not we need to fix bug 28945. Just expose this commit for code review, since I had it anyway.