### PR TITLE
Fix pkmean and pkmid signals

### DIFF
--- a/hdf/HDFPulseCallsWriter.cpp
+++ b/hdf/HDFPulseCallsWriter.cpp
@@ -225,10 +225,10 @@ bool HDFPulseCallsWriter::_WriteLabelQV(const PacBio::BAM::BamRecord & read) {
 bool HDFPulseCallsWriter::_WritePkmean(const PacBio::BAM::BamRecord & read) {
     if (HasPkmean()) {
         if (read.HasPkmean()) {
-            const std::vector<float> & qvs = read.Pkmean();
-            _CheckRead(read, qvs.size(), "Pkmean");
-            std::vector<HalfWord> data(qvs.begin(), qvs.end());
-            pkmeanArray_.Write(&data[0], qvs.size());
+            const PacBio::BAM::Tag & tag = read.Impl().TagValue("pa");
+            std::vector<uint16_t> data = tag.ToUInt16Array();
+            _CheckRead(read, data.size(), "Pkmean");
+            pkmeanArray_.Write(&data[0], data.size());
         } else {
             AddErrorMessage(std::string("Pkmean is absent in read " + read.FullName()));
         }
@@ -253,10 +253,10 @@ bool HDFPulseCallsWriter::_WritePulseMergeQV(const PacBio::BAM::BamRecord & read
 bool HDFPulseCallsWriter::_WritePkmid(const PacBio::BAM::BamRecord & read) {
     if (HasPkmid()) {
         if (read.HasPkmid()) {
-            const std::vector<float> & qvs = read.Pkmid();
-            std::vector<HalfWord> data(qvs.begin(), qvs.end());
+            const PacBio::BAM::Tag & tag = read.Impl().TagValue("pm");
+            std::vector<uint16_t> data = tag.ToUInt16Array();
             _CheckRead(read, data.size(), "Pkmid");
-            pkmidArray_.Write(&data[0], qvs.size());
+            pkmidArray_.Write(&data[0], data.size());
         } else {
             AddErrorMessage(std::string("Pkmid is absent in read " + read.FullName()));
         }

--- a/hdf/HDFPulseCallsWriter.hpp
+++ b/hdf/HDFPulseCallsWriter.hpp
@@ -131,11 +131,11 @@ private:
 	BufferedHDFArray<unsigned char> labelQVArray_; 
     // FIXME: pkmean is 2D array (one value per pulse per channel) in H5,
     // while is 1D array (one value per pulse) in BAM.
-	BufferedHDFArray<HalfWord>      pkmeanArray_;
+	BufferedHDFArray<uint16_t>      pkmeanArray_;
 	BufferedHDFArray<unsigned char> pulseMergeQVArray_;
-	BufferedHDFArray<HalfWord>      pkmidArray_;
+	BufferedHDFArray<uint16_t>      pkmidArray_;
 	BufferedHDFArray<uint32_t>      startFrameArray_;
-	BufferedHDFArray<HalfWord>      pulseCallWidthArray_;
+	BufferedHDFArray<uint16_t>      pulseCallWidthArray_;
 	BufferedHDFArray<unsigned char> altLabelArray_;
 	BufferedHDFArray<unsigned char> altLabelQVArray_;
 


### PR DESCRIPTION
Fix pkmean and pkmid signals. 
pbbam public apis (i.e., BamReacord.PkMean() and BamRecord.PkMid()) still return incorrect signals, let's fall back to lower-level api instead.