### PR TITLE
Fix relative and clarify external incs

### DIFF
--- a/alignment/algorithms/alignment/AffineKBandAlign.hpp
+++ b/alignment/algorithms/alignment/AffineKBandAlign.hpp
@@ -4,10 +4,10 @@
 #include <cassert>
 #include <vector>
 #include <iostream>
-#include "NucConversion.hpp"
-#include "defs.h"
-#include "matrix/FlatMatrix.hpp"
-#include "datastructures/alignment/Alignment.hpp"
+#include <NucConversion.hpp> // pbdata
+#include <defs.h> // pbdata
+#include <matrix/FlatMatrix.hpp> // pbdata
+#include "../../datastructures/alignment/Alignment.hpp"
 #include "KBandAlign.hpp"
 
 template<typename T_QuerySequence, typename T_TargetSequence, typename T_Alignment>

--- a/alignment/algorithms/alignment/AlignmentUtils.hpp
+++ b/alignment/algorithms/alignment/AlignmentUtils.hpp
@@ -2,9 +2,9 @@
 #define _BLASR_ALIGNMENT_UTILS_HPP_
 
 #include <string>
-#include "DNASequence.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "algorithms/alignment/DistanceMatrixScoreFunction.hpp"
+#include <DNASequence.hpp> // pbdata
+#include "../../datastructures/alignment/Alignment.hpp"
+#include "DistanceMatrixScoreFunction.hpp"
 
 enum AlignmentType { 
     Local,     // Standard Smith-Waterman

--- a/alignment/algorithms/alignment/DistanceMatrixScoreFunctionImpl.hpp
+++ b/alignment/algorithms/alignment/DistanceMatrixScoreFunctionImpl.hpp
@@ -6,12 +6,14 @@
 #include <string>
 #include <cstring>
 #include <ostream>
-#include "Types.h"
-#include "NucConversion.hpp"
-#include "Enumerations.h"
-#include "DNASequence.hpp"
-#include "FASTASequence.hpp"
-#include "FASTQSequence.hpp"
+// pbdata
+#include <Types.h>
+#include <NucConversion.hpp>
+#include <Enumerations.h>
+#include <DNASequence.hpp>
+#include <FASTASequence.hpp>
+#include <FASTQSequence.hpp>
+
 #include "DistanceMatrixScoreFunction.hpp"
 
 template<typename T_RefSequence, typename T_QuerySequence>

--- a/alignment/algorithms/alignment/ExtendAlign.hpp
+++ b/alignment/algorithms/alignment/ExtendAlign.hpp
@@ -3,11 +3,13 @@
 
 #include <vector>
 #include <algorithm>
-#include "defs.h"
+// pbdata
+#include <defs.h>
+#include <NucConversion.hpp>
+#include <matrix/FlatMatrix.hpp>
+
+#include "../../datastructures/alignment/Alignment.hpp"
 #include "KBandAlign.hpp"
-#include "NucConversion.hpp"
-#include "matrix/FlatMatrix.hpp"
-#include "datastructures/alignment/Alignment.hpp"
 
 //FIXME: change data type of target pos from int to GenomeLength 
 //       in order to support > 4G genome.

--- a/alignment/algorithms/alignment/FullQVAlign.hpp
+++ b/alignment/algorithms/alignment/FullQVAlign.hpp
@@ -1,9 +1,9 @@
 #ifndef _BLASR_FULL_QV_ALIGN_HPP_
 #define _BLASR_FULL_QV_ALIGN_HPP_
-
-#include "matrix/Matrix.hpp"
-#include "FASTQSequence.hpp"
-#include "FASTASequence.hpp"
+// pbdata
+#include <matrix/Matrix.hpp>
+#include <FASTQSequence.hpp>
+#include <FASTASequence.hpp>
 
 template<typename T_Query, typename T_Reference>
 double FullQVAlign(T_Query       &query,

--- a/alignment/algorithms/alignment/GraphPaper.hpp
+++ b/alignment/algorithms/alignment/GraphPaper.hpp
@@ -1,8 +1,8 @@
 #ifndef GRAPH_PAPER_HPP_
 #define GRAPH_PAPER_HPP_
 
-#include "datastructures/alignment/Path.h"
-#include "matrix/FlatMatrix.hpp"
+#include "../../datastructures/alignment/Path.h"
+#include <matrix/FlatMatrix.hpp> // pbdata
 
 template<typename T_Point>
 bool SetBounds(vector<T_Point> &points, 

--- a/alignment/algorithms/alignment/GuidedAlign.hpp
+++ b/alignment/algorithms/alignment/GuidedAlign.hpp
@@ -5,25 +5,27 @@
 #include <cmath>
 #include <limits.h>
 #include <ostream>
-#include "Types.h"
-#include "defs.h"
-#include "NucConversion.hpp"
-#include "DNASequence.hpp"
+// pbdata
+#include <Types.h>
+#include <defs.h>
+#include <NucConversion.hpp>
+#include <DNASequence.hpp>
+#include <matrix/FlatMatrix.hpp>
+#include <matrix/Matrix.hpp>
+#include <qvs/QualityValue.hpp>
+#include <qvs/QualityValueVector.hpp>
+
+#include "../../utils/LogUtils.hpp"
+#include "../../utils/PhredUtils.hpp"
+#include "../../datastructures/alignment/Alignment.hpp"
+#include "../../datastructures/anchoring/MatchPos.hpp"
+#include "../../tuples/TupleList.hpp"
+#include "../../tuples/TupleMetrics.hpp"
+#include "../../tuples/DNATuple.hpp"
 #include "sdp/SDPFragment.hpp"
-#include "matrix/FlatMatrix.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "datastructures/anchoring/MatchPos.hpp"
-#include "matrix/Matrix.hpp"
-#include "tuples/TupleList.hpp"
-#include "tuples/TupleMetrics.hpp"
-#include "tuples/DNATuple.hpp"
-#include "utils/LogUtils.hpp"
-#include "utils/PhredUtils.hpp"
-#include "qvs/QualityValue.hpp"
-#include "qvs/QualityValueVector.hpp"
 #include "AlignmentUtils.hpp"
 #include "DistanceMatrixScoreFunction.hpp"
-#include "algorithms/alignment/SDPAlign.hpp"
+#include "SDPAlign.hpp"
 
 #define LOWEST_LOG_VALUE  -700
 

--- a/alignment/algorithms/alignment/IDSScoreFunction.hpp
+++ b/alignment/algorithms/alignment/IDSScoreFunction.hpp
@@ -5,9 +5,10 @@
 #include <cmath>
 #include "ScoreMatrices.hpp"
 #include "BaseScoreFunction.hpp"
-#include "FASTASequence.hpp"
-#include "FASTQSequence.hpp"
-#include "utils/LogUtils.hpp"
+#include "../../utils/LogUtils.hpp"
+// pbdata
+#include <FASTASequence.hpp>
+#include <FASTQSequence.hpp>
 
 float SumAsValidPhred(float v1, float v2, float v3); 
 

--- a/alignment/algorithms/alignment/KBandAlign.cpp
+++ b/alignment/algorithms/alignment/KBandAlign.cpp
@@ -1,4 +1,4 @@
-#include "algorithms/alignment/KBandAlign.hpp"
+#include "KBandAlign.hpp"
 
 DefaultGuide::DefaultGuide() {}
 

--- a/alignment/algorithms/alignment/KBandAlign.hpp
+++ b/alignment/algorithms/alignment/KBandAlign.hpp
@@ -4,12 +4,14 @@
 #include <algorithm>
 #include <vector>
 #include <limits.h>
-#include "defs.h"
+// pbdata
+#include <defs.h>
+#include <NucConversion.hpp>
+#include <matrix/FlatMatrix.hpp>
+
 #include "AlignmentUtils.hpp"
-#include "NucConversion.hpp"
-#include "matrix/FlatMatrix.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "statistics/StatUtils.hpp"
+#include "../../datastructures/alignment/Alignment.hpp"
+#include "../../statistics/StatUtils.hpp"
 
 class DefaultGuide {
  public:

--- a/alignment/algorithms/alignment/OneGapAlignment.hpp
+++ b/alignment/algorithms/alignment/OneGapAlignment.hpp
@@ -2,11 +2,13 @@
 #define _BLASR_ONEGAP_ALIGNMENT_HPP_
 
 #include <limits.h>
-#include "Types.h"
-#include "FASTQSequence.hpp"
-#include "matrix/FlatMatrix.hpp"
-#include "datastructures/alignment/Path.h"
-#include "datastructures/alignment/Alignment.hpp"
+// pbdata
+#include <Types.h>
+#include <FASTQSequence.hpp>
+#include <matrix/FlatMatrix.hpp>
+
+#include "../../datastructures/alignment/Path.h"
+#include "../../datastructures/alignment/Alignment.hpp"
 
 /*
    Perform gapped alignment that aligns the entire query sequence to

--- a/alignment/algorithms/alignment/QualityValueScoreFunction.hpp
+++ b/alignment/algorithms/alignment/QualityValueScoreFunction.hpp
@@ -1,8 +1,10 @@
 #ifndef _BLASR_QUALITY_VALUE_SCORE_FUNCTION_HPP_
 #define _BLASR_QUALITY_VALUE_SCORE_FUNCTION_HPP_
-#include "FASTASequence.hpp"
-#include "FASTQSequence.hpp"
-#include "NucConversion.hpp"
+// pbdata
+#include <FASTASequence.hpp>
+#include <FASTQSequence.hpp>
+#include <NucConversion.hpp>
+
 #include "ScoreMatrices.hpp"
 #include "BaseScoreFunction.hpp"
 

--- a/alignment/algorithms/alignment/SDPAlign.hpp
+++ b/alignment/algorithms/alignment/SDPAlign.hpp
@@ -1,11 +1,12 @@
 #ifndef _BLASR_SDP_ALIGN_HPP_
 #define _BLASR_SDP_ALIGN_HPP_
+// pbdata
+#include <DNASequence.hpp>
+#include <FASTASequence.hpp>
+#include <FASTQSequence.hpp>
 
-#include "DNASequence.hpp"
-#include "tuples/TupleMatching.hpp"
+#include "../../tuples/TupleMatching.hpp"
 #include "sdp/SDPFragment.hpp"
-#include "FASTASequence.hpp"
-#include "FASTQSequence.hpp"
 #include "DistanceMatrixScoreFunction.hpp"
 
 #define SDP_DETAILED_WORD_SIZE 5

--- a/alignment/algorithms/alignment/SDPAlignImpl.hpp
+++ b/alignment/algorithms/alignment/SDPAlignImpl.hpp
@@ -6,17 +6,19 @@
 #include <math.h>
 #include <cstdlib>
 #include <ostream>
-#include "Types.h"
-#include "defs.h"
-#include "utils.hpp"
-#include "Enumerations.h"
-#include "DNASequence.hpp"
-#include "matrix/FlatMatrix.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "sdp/SDPFragment.hpp"
+// pbdata
+#include <Types.h>
+#include <defs.h>
+#include <utils.hpp>
+#include <Enumerations.h>
+#include <DNASequence.hpp>
+#include <matrix/FlatMatrix.hpp>
+
+#include "../../datastructures/alignment/Alignment.hpp"
 #include "GraphPaper.hpp"
 #include "AlignmentUtils.hpp"
 #include "SWAlign.hpp"
+#include "sdp/SDPFragment.hpp"
 #include "sdp/SparseDynamicProgramming.hpp"
 #include "SDPAlign.hpp"
 

--- a/alignment/algorithms/alignment/SWAlignImpl.hpp
+++ b/alignment/algorithms/alignment/SWAlignImpl.hpp
@@ -3,14 +3,16 @@
 #include <stdint.h>
 #include <iostream>
 #include <ostream>
-#include "Types.h"
-#include "defs.h"
-#include "DNASequence.hpp"
-#include "matrix/FlatMatrix.hpp"
-#include "datastructures/alignment/Path.h"
-#include "datastructures/alignment/AlignmentMap.hpp"
-#include "datastructures/alignment/AlignmentStats.hpp"
-#include "datastructures/alignment/Alignment.hpp"
+// pbdata
+#include <Types.h>
+#include <defs.h>
+#include <DNASequence.hpp>
+#include <matrix/FlatMatrix.hpp>
+
+#include "../../datastructures/alignment/Path.h"
+#include "../../datastructures/alignment/AlignmentMap.hpp"
+#include "../../datastructures/alignment/AlignmentStats.hpp"
+#include "../../datastructures/alignment/Alignment.hpp"
 #include "AlignmentUtils.hpp"
 #include "SWAlign.hpp"
 

--- a/alignment/algorithms/alignment/sdp/SDPSetImpl.hpp
+++ b/alignment/algorithms/alignment/sdp/SDPSetImpl.hpp
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include <set>
-#include "Types.h"
+#include <Types.h> // pbdata
 #include "SDPSet.hpp"
 
 template<typename T>

--- a/alignment/algorithms/alignment/sdp/SparseDynamicProgramming.hpp
+++ b/alignment/algorithms/alignment/sdp/SparseDynamicProgramming.hpp
@@ -3,11 +3,11 @@
 
 #include <vector>
 #include <string>
-#include "Types.h"
-#include "defs.h"
-#include "DNASequence.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "algorithms/alignment/AlignmentUtils.hpp"
+#include <Types.h> // pbdata
+#include <defs.h> // pbdata
+#include <DNASequence.hpp> // pbdata
+#include "../../../datastructures/alignment/Alignment.hpp"
+#include "../AlignmentUtils.hpp"
 
 /*******************************************************************************
  *  Sparse dynamic programming implementation of Longest Common Subsequence

--- a/alignment/algorithms/anchoring/BWTSearch.cpp
+++ b/alignment/algorithms/anchoring/BWTSearch.cpp
@@ -1,4 +1,4 @@
-#include "algorithms/anchoring/BWTSearch.hpp"
+#include "BWTSearch.hpp"
 
 int MapReadToGenome(BWT & bwt,
 	FASTASequence & seq,

--- a/alignment/algorithms/anchoring/BWTSearch.hpp
+++ b/alignment/algorithms/anchoring/BWTSearch.hpp
@@ -2,10 +2,10 @@
 #define _BLASR_BWT_SEARCH_HPP_
 
 #include <vector>
-#include "FASTASequence.hpp"
-#include "bwt/BWT.hpp"
-#include "datastructures/anchoring/MatchPos.hpp"
-#include "datastructures/anchoring/AnchorParameters.hpp"
+#include <FASTASequence.hpp> // pbdata
+#include "../../bwt/BWT.hpp"
+#include "../../datastructures/anchoring/MatchPos.hpp"
+#include "../../datastructures/anchoring/AnchorParameters.hpp"
 
 int MapReadToGenome(BWT & bwt,
 	FASTASequence & seq,
@@ -30,6 +30,6 @@ int MapReadToGenome(BWT & bwt,
     AnchorParameters & params, int & numBasesAnchored, 
     T_MappingBuffers & mappingBuffers);
 
-#include "algorithms/anchoring/BWTSearchImpl.hpp"
+#include "BWTSearchImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/BasicEndpoint.hpp
+++ b/alignment/algorithms/anchoring/BasicEndpoint.hpp
@@ -1,8 +1,8 @@
 #ifndef _BLASR_BASIC_ENDPOINT_HPP_
 #define _BLASR_BASIC_ENDPOINT_HPP_
 
-#include "Types.h"
-#include "algorithms/anchoring/Coordinate.hpp"
+#include <Types.h> // pbdata
+#include "Coordinate.hpp"
 //
 // An endpoint is one of the ends of a fragment, where
 // a fragment is an exact match between two genomes. 
@@ -45,6 +45,6 @@ public:
     void SetChainPrev(T_ScoredFragment* prevChainFragment);
 };
 
-#include "algorithms/anchoring/BasicEndpointImpl.hpp"
+#include "BasicEndpointImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/BasicEndpointImpl.hpp
+++ b/alignment/algorithms/anchoring/BasicEndpointImpl.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_BASIC_ENDPOINT_IMPL_HPP_
 #define _BLASR_BASIC_ENDPOINT_IMPL_HPP_
 
-#include "algorithms/anchoring/BasicEndpoint.hpp"
+#include "BasicEndpoint.hpp"
 /*
  An endpoint is one of the ends of a fragment, where
  a fragment is an exact match between two genomes. 

--- a/alignment/algorithms/anchoring/ClusterProbability.cpp
+++ b/alignment/algorithms/anchoring/ClusterProbability.cpp
@@ -1,4 +1,4 @@
-#include "algorithms/anchoring/ClusterProbability.hpp"
+#include "ClusterProbability.hpp"
 #include <cassert>
 #include <math.h>
 

--- a/alignment/algorithms/anchoring/Coordinate.cpp
+++ b/alignment/algorithms/anchoring/Coordinate.cpp
@@ -1,4 +1,4 @@
-#include "algorithms/anchoring/Coordinate.hpp"
+#include "Coordinate.hpp"
 
 
 int Coordinate::operator<=(const Coordinate &rhs) const {

--- a/alignment/algorithms/anchoring/Coordinate.hpp
+++ b/alignment/algorithms/anchoring/Coordinate.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_COORDINATE_HPP_
 #define _BLASR_COORDINATE_HPP_
 
-#include "Types.h"
+#include <Types.h> // pbdata
 
 class Coordinate {
 private:

--- a/alignment/algorithms/anchoring/FindMaxInterval.cpp
+++ b/alignment/algorithms/anchoring/FindMaxInterval.cpp
@@ -1,4 +1,4 @@
-#include "algorithms/anchoring/FindMaxInterval.hpp"
+#include "FindMaxInterval.hpp"
 
 unsigned int NumRemainingBases(DNALength curPos, DNALength intervalLength) {
   if (curPos > intervalLength) {

--- a/alignment/algorithms/anchoring/FindMaxInterval.hpp
+++ b/alignment/algorithms/anchoring/FindMaxInterval.hpp
@@ -5,13 +5,13 @@
 #include <math.h>
 #include <fstream>
 #include <iostream>
-#include "algorithms/anchoring/LongestIncreasingSubsequence.hpp"
-#include "algorithms/anchoring/GlobalChain.hpp"
-#include "algorithms/anchoring/BasicEndpoint.hpp"
-#include "datastructures/anchoring/WeightedInterval.hpp"
-#include "datastructures/anchoring/MatchPos.hpp"
-#include "datastructures/anchoring/ClusterList.hpp"
-#include "statistics/VarianceAccumulator.hpp"
+#include "LongestIncreasingSubsequence.hpp"
+#include "GlobalChain.hpp"
+#include "BasicEndpoint.hpp"
+#include "../../datastructures/anchoring/WeightedInterval.hpp"
+#include "../../datastructures/anchoring/MatchPos.hpp"
+#include "../../datastructures/anchoring/ClusterList.hpp"
+#include "../../statistics/VarianceAccumulator.hpp"
 
 unsigned int NumRemainingBases(DNALength curPos, DNALength intervalLength);
 
@@ -171,5 +171,5 @@ int ExhaustiveFindMaxIncreasingInterval(
         VarianceAccumulator<float> &accumPValue, 
         VarianceAccumulator<float> &accumWeight);
 
-#include "algorithms/anchoring/FindMaxIntervalImpl.hpp"
+#include "FindMaxIntervalImpl.hpp"
 #endif

--- a/alignment/algorithms/anchoring/GlobalChain.hpp
+++ b/alignment/algorithms/anchoring/GlobalChain.hpp
@@ -2,9 +2,11 @@
 #define _BLASR_GLOBAL_CHAIN_HPP_
 
 #include <vector>
-#include "Types.h"
-#include "DNASequence.hpp"
-#include "algorithms/anchoring/PrioritySearchTree.hpp"
+// pbdata
+#include <Types.h>
+#include <DNASequence.hpp>
+
+#include "PrioritySearchTree.hpp"
 
 template<typename T_Fragment, typename T_Endpoint>
 void FragmentSetToEndpoints(T_Fragment* fragments, int nFragments, 
@@ -32,6 +34,6 @@ int GlobalChain(std::vector<T_Fragment> &fragments,
     std::vector<VectorIndex> &optFragmentChainIndices,
     std::vector<T_Endpoint> *bufEndpointsPtr = NULL);
 
-#include "algorithms/anchoring/GlobalChainImpl.hpp"
+#include "GlobalChainImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/GlobalChainImpl.hpp
+++ b/alignment/algorithms/anchoring/GlobalChainImpl.hpp
@@ -2,9 +2,11 @@
 #define _BLASR_GLOBAL_CHAIN_IMPL_HPP_
 
 #include <algorithm>
-#include "Types.h"
-#include "DNASequence.hpp"
-#include "algorithms/anchoring/PrioritySearchTree.hpp"
+// pbdata
+#include <Types.h>
+#include <DNASequence.hpp>
+
+#include "PrioritySearchTree.hpp"
 
 using namespace std;
 

--- a/alignment/algorithms/anchoring/LISPValue.hpp
+++ b/alignment/algorithms/anchoring/LISPValue.hpp
@@ -2,9 +2,9 @@
 #define _BLASR_LISPVALUE_HPP_
 
 #include <math.h>
-#include "datastructures/anchoring/MatchPos.hpp"
-#include "tuples/TupleCountTable.hpp"
-#include "algorithms/anchoring/ScoreAnchors.hpp"
+#include "../../datastructures/anchoring/MatchPos.hpp"
+#include "../../tuples/TupleCountTable.hpp"
+#include "ScoreAnchors.hpp"
 
 template<typename T_MatchPos>
 void StoreNonOverlappingIndices(std::vector<T_MatchPos> &lis, 
@@ -19,6 +19,6 @@ float ComputeLISPValue(std::vector<T_MatchPos> &lis,
 	TupleMetrics &tm, TupleCountTable<T_TextSequence, T_Tuple> &ct,
     int &lisNBases, int &lisSize );
 
-#include "algorithms/anchoring/LISPValueImpl.hpp"
+#include "LISPValueImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/LISPValueWeightor.hpp
+++ b/alignment/algorithms/anchoring/LISPValueWeightor.hpp
@@ -1,8 +1,8 @@
 #ifndef _BLASR_LISPVALUE_WEIGHTOR_HPP_
 #define _BLASR_LISPVALUE_WEIGHTOR_HPP_
 
-#include "algorithms/anchoring/LISPValue.hpp"
-#include "tuples/TupleMetrics.hpp"
+#include "LISPValue.hpp"
+#include "../../tuples/TupleMetrics.hpp"
 
 template<typename T_RefSequence, typename T_MatchList>
 class LISSumOfLogPWeightor {
@@ -47,6 +47,6 @@ public:
     float operator()(T_MatchList &matchList);
 };
 
-#include "algorithms/anchoring/LISPValueWeightorImpl.hpp"
+#include "LISPValueWeightorImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/LISPValueWeightorImpl.hpp
+++ b/alignment/algorithms/anchoring/LISPValueWeightorImpl.hpp
@@ -1,8 +1,8 @@
 #ifndef _BLASR_LISPVALUE_WEIGHTOR_IMPL_HPP_
 #define _BLASR_LISPVALUE_WEIGHTOR_IMPL_HPP_
 
-#include "algorithms/anchoring/LISPValue.hpp"
-#include "tuples/TupleMetrics.hpp"
+#include "LISPValue.hpp"
+#include "../../tuples/TupleMetrics.hpp"
 
 template<typename T_RefSequence, typename T_MatchList>
 LISSumOfLogPWeightor<T_RefSequence, T_MatchList>::LISSumOfLogPWeightor(

--- a/alignment/algorithms/anchoring/LISQValueWeightor.hpp
+++ b/alignment/algorithms/anchoring/LISQValueWeightor.hpp
@@ -1,9 +1,10 @@
 #ifndef _BLASR_LIS_QVALUE_WEIGHTOR_HPP_
 #define _BLASR_LIS_QVALUE_WEIGHTOR_HPP_
 
-#include "qvs/QualityValue.hpp"
-#include "DNASequence.hpp"
-#include "FASTQSequence.hpp"
+// pbdata
+#include <qvs/QualityValue.hpp>
+#include <DNASequence.hpp>
+#include <FASTQSequence.hpp>
 
 template<typename T_MatchList, typename T_Sequence>
 class LISQValueWeightor {

--- a/alignment/algorithms/anchoring/LISSizeWeightor.hpp
+++ b/alignment/algorithms/anchoring/LISSizeWeightor.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_LIS_SIZE_WEIGHTOR_HPP_
 #define _BLASR_LIS_SIZE_WEIGHTOR_HPP_
 
-#include "Types.h"
+#include <Types.h> // pbdata
 
 template<typename T_MatchList>
 class LISSizeWeightor {
@@ -9,6 +9,6 @@ public:
 	MatchWeight operator()(T_MatchList &matchList);
 };
 
-#include "algorithms/anchoring/LISSizeWeightorImpl.hpp"
+#include "LISSizeWeightorImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/LongestIncreasingSubsequence.hpp
+++ b/alignment/algorithms/anchoring/LongestIncreasingSubsequence.hpp
@@ -26,6 +26,6 @@ int LongestIncreasingSubset(T *x, int xLength, vector<int> &subsetIndices,
 template<typename T, typename F_IntValue>
 int LongestIncreasingSubset(T*x, int& xLength, vector<int> &subsetIndices);
 
-#include "algorithms/anchoring/LongestIncreasingSubsequenceImpl.hpp"
+#include "LongestIncreasingSubsequenceImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/MapBySuffixArray.hpp
+++ b/alignment/algorithms/anchoring/MapBySuffixArray.hpp
@@ -2,11 +2,11 @@
 #define _BLASR_MAP_BY_SUFFIX_ARRAY_HPP_
 
 #include <algorithm>
-#include "suffixarray/SuffixArray.hpp"
-#include "datastructures/anchoring/MatchPos.hpp"
-#include "datastructures/anchoring/AnchorParameters.hpp"
-#include "algorithms/alignment/SWAlign.hpp"
-#include "algorithms/alignment/ScoreMatrices.hpp"
+#include "../../suffixarray/SuffixArray.hpp"
+#include "../../datastructures/anchoring/MatchPos.hpp"
+#include "../../datastructures/anchoring/AnchorParameters.hpp"
+#include "../../algorithms/alignment/SWAlign.hpp"
+#include "../../algorithms/alignment/ScoreMatrices.hpp"
 
 /*
  * Parameters:
@@ -40,5 +40,5 @@ int MapReadToGenome(T_RefSequence &reference,
 	vector<T_MatchPos> &matchPosList,
 	AnchorParameters &anchorParameters);
 
-#include "algorithms/anchoring/MapBySuffixArrayImpl.hpp"
+#include "MapBySuffixArrayImpl.hpp"
 #endif

--- a/alignment/algorithms/anchoring/MapBySuffixArrayImpl.hpp
+++ b/alignment/algorithms/anchoring/MapBySuffixArrayImpl.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_MAP_BY_SUFFIX_ARRAY_IMPL_HPP_
 #define _BLASR_MAP_BY_SUFFIX_ARRAY_IMPL_HPP_
-#include "defs.h" 
-#include "algorithms/anchoring/MapBySuffixArray.hpp"
+#include <defs.h> // pbdata
+#include "MapBySuffixArray.hpp"
 
 /*
  * Parameters:

--- a/alignment/algorithms/anchoring/PrioritySearchTree.hpp
+++ b/alignment/algorithms/anchoring/PrioritySearchTree.hpp
@@ -2,7 +2,7 @@
 #define _BLASR_PRIORITY_SEARCH_TREE_HPP_
 
 #include <vector>
-#include "algorithms/anchoring/BasicEndpoint.hpp"
+#include "BasicEndpoint.hpp"
 
 /*
  * Define a priority search tree on a point that implements 
@@ -64,6 +64,6 @@ public:
         KeyType maxPointKey, int &maxPointIndex);
 };
 
-#include "algorithms/anchoring/PrioritySearchTreeImpl.hpp"
+#include "PrioritySearchTreeImpl.hpp"
 
 #endif

--- a/alignment/algorithms/anchoring/ScoreAnchors.hpp
+++ b/alignment/algorithms/anchoring/ScoreAnchors.hpp
@@ -2,11 +2,11 @@
 #define _BLASR_SCORE_ANCHORS_HPP_
 
 #include <math.h>
-#include "tuples/TupleCountTable.hpp"
-#include "tuples/DNATuple.hpp"
-#include "tuples/TupleMetrics.hpp"
-#include "statistics/cdfs.hpp"
-#include "statistics/pdfs.hpp"
+#include "../../tuples/TupleCountTable.hpp"
+#include "../../tuples/DNATuple.hpp"
+#include "../../tuples/TupleMetrics.hpp"
+#include "../../statistics/cdfs.hpp"
+#include "../../statistics/pdfs.hpp"
 
 template<typename TSequence, typename T_Tuple>
 int GetTupleCount(TSequence &seq, DNALength startPos, 

--- a/alignment/algorithms/sorting/DifferenceCovers.cpp
+++ b/alignment/algorithms/sorting/DifferenceCovers.cpp
@@ -1,5 +1,5 @@
 #include <cstring>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 #include "DifferenceCovers.hpp"
 
 int InitializeDifferenceCover(UInt diffCoverSize, UInt &diffCoverLength, UInt *&diffCover) {

--- a/alignment/algorithms/sorting/DifferenceCovers.hpp
+++ b/alignment/algorithms/sorting/DifferenceCovers.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_DIFFERENCE_COVERS_HPP_
 #define _BLASR_DIFFERENCE_COVERS_HPP_
 
-#include "Types.h"
+#include <Types.h> // pbdata
 
 #define N_COVERS 5
 const UInt diffCovers[N_COVERS][60] = {

--- a/alignment/algorithms/sorting/Karkkainen.hpp
+++ b/alignment/algorithms/sorting/Karkkainen.hpp
@@ -1,7 +1,7 @@
 #ifndef ALGORITHMS_SORTING_KARKKAINEN_HPP_
 #define ALGORITHMS_SORTING_KARKKAINEN_HPP_
 
-#include "DNASequence.hpp"
+#include <DNASequence.hpp> // pbdata
 
 inline bool 
 leq(DNALength a1, DNALength a2,   DNALength b1, DNALength b2) // lexicographic order

--- a/alignment/algorithms/sorting/LightweightSuffixArray.cpp
+++ b/alignment/algorithms/sorting/LightweightSuffixArray.cpp
@@ -1,4 +1,4 @@
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 #include "LightweightSuffixArray.hpp"
 
 UInt DiffMod(UInt a, UInt b, UInt d) {

--- a/alignment/algorithms/sorting/LightweightSuffixArray.hpp
+++ b/alignment/algorithms/sorting/LightweightSuffixArray.hpp
@@ -5,7 +5,7 @@
 #include "qsufsort.hpp"
 #include "MultikeyQuicksort.hpp"
 #include "DifferenceCovers.hpp"
-#include "Types.h"
+#include <Types.h> // pbdata
 
 /*
  * a - b potentially may not fit into a signed type.  Use some logic

--- a/alignment/algorithms/sorting/MultikeyQuicksort.hpp
+++ b/alignment/algorithms/sorting/MultikeyQuicksort.hpp
@@ -16,9 +16,10 @@
 #include <limits.h>
 #include <vector>
 #include <algorithm>
-#include "NucConversion.hpp"
-#include "FASTASequence.hpp"
-#include "Types.h"
+// pbdata
+#include <NucConversion.hpp>
+#include <FASTASequence.hpp>
+#include <Types.h>
 
 typedef unsigned int UInt;
 

--- a/alignment/algorithms/sorting/qsufsort.hpp
+++ b/alignment/algorithms/sorting/qsufsort.hpp
@@ -1,6 +1,6 @@
 #ifndef _BLASR_QSUFSORT_HPP_
 #define _BLASR_QSUFSORT_HPP_
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 #include <assert.h>
 
 void suffixsort(int *x, int *p, int n, int k, int l);

--- a/alignment/anchoring/AnchorParameters.hpp
+++ b/alignment/anchoring/AnchorParameters.hpp
@@ -3,8 +3,8 @@
 
 #include <fstream>
 #include <iostream>
-#include "qvs/QualityValue.hpp"
-#include "DNASequence.hpp"
+#include <qvs/QualityValue.hpp> // pbdata
+#include <DNASequence.hpp> // pbdata
 
 class AnchorParameters {
 public:

--- a/alignment/bwt/BWT.hpp
+++ b/alignment/bwt/BWT.hpp
@@ -5,9 +5,9 @@
 #include <fstream>
 #include "Occ.hpp"
 #include "Pos.hpp"
-#include "suffixarray/SuffixArray.hpp"
+#include "../suffixarray/SuffixArray.hpp"
 #include "PackedDNASequence.hpp"
-#include "FASTASequence.hpp"
+#include <FASTASequence.hpp> // pbdata
 
 /*
  * Define an Occurrence table appropriate for Gb sized genomes.

--- a/alignment/bwt/Occ.hpp
+++ b/alignment/bwt/Occ.hpp
@@ -4,11 +4,11 @@
 #include <fstream>
 #include <vector>
 #include <algorithm>
-#include "DNASequence.hpp"
-#include "NucConversion.hpp"
-#include "utils.hpp"
-#include "matrix/Matrix.hpp"
-#include "matrix/FlatMatrix.hpp"
+#include <DNASequence.hpp> // pbdata
+#include <NucConversion.hpp> // pbdata
+#include <utils.hpp> // pbdata
+#include <matrix/Matrix.hpp> // pbdata
+#include <matrix/FlatMatrix.hpp> // pbdata
 
 template<typename T_BWTSequence, typename T_Major, typename T_Minor>
 class Occ {

--- a/alignment/bwt/PackedHash.hpp
+++ b/alignment/bwt/PackedHash.hpp
@@ -6,10 +6,10 @@
 #include <iostream>
 #include <fstream>
 #include <cstring>
-#include "Types.h"
-#include "utils.hpp"
+#include <Types.h> // pbdata
+#include <utils.hpp> // pbdata
 #include "utils/BitUtils.hpp"
-#include "DNASequence.hpp"
+#include <DNASequence.hpp> // pbdata
 
 class PackedHash {
 public:

--- a/alignment/bwt/Pos.hpp
+++ b/alignment/bwt/Pos.hpp
@@ -6,8 +6,8 @@
 
 #include "PackedHash.hpp"
 
-#include "DNASequence.hpp"
-#include "Types.h"
+#include <DNASequence.hpp> // pbdata
+#include <Types.h> // pbdata
 #include "utils/BitUtils.hpp"
 
 template< typename T_BWT_Sequence>

--- a/alignment/datastructures/alignment/Alignment.cpp
+++ b/alignment/datastructures/alignment/Alignment.cpp
@@ -6,9 +6,9 @@
 #include <iostream>
 #include <ostream>
 #include <fstream>
-#include "Types.h"
-#include "DNASequence.hpp"
-#include "datastructures/alignment/Alignment.hpp"
+#include <Types.h> // pbdata
+#include <DNASequence.hpp> // pbdata
+#include "Alignment.hpp"
 
 using namespace blasr;
 

--- a/alignment/datastructures/alignment/Alignment.hpp
+++ b/alignment/datastructures/alignment/Alignment.hpp
@@ -2,10 +2,10 @@
 #define _BLASR_ALIGNMENT_HPP_
 
 #include "Path.h"
+#include "AlignmentStats.hpp"
 #include <vector>
 #include <string>
-#include "DNASequence.hpp"
-#include "datastructures/alignment/AlignmentStats.hpp"
+#include <DNASequence.hpp> // pbdata
 
 namespace blasr {
 class Block {

--- a/alignment/datastructures/alignment/AlignmentCandidate.hpp
+++ b/alignment/datastructures/alignment/AlignmentCandidate.hpp
@@ -2,8 +2,9 @@
 #define _ALIGNMENT_ALIGNMENT_CANDIDATE_HPP_
 
 #include "Alignment.hpp"
-#include "DNASequence.hpp"
-#include "FASTQSequence.hpp"
+// pbdata
+#include <DNASequence.hpp>
+#include <FASTQSequence.hpp>
 
 template<typename T_TSequence=FASTASequence, typename T_QSequence=FASTASequence>
 class AlignmentCandidate : public blasr::Alignment {

--- a/alignment/datastructures/alignment/AlignmentContext.hpp
+++ b/alignment/datastructures/alignment/AlignmentContext.hpp
@@ -2,7 +2,8 @@
 #define _BLASR_ALIGNMENT_CONTEXT_HPP_
 
 #include <string>
-#include "Enumerations.h"
+// pbdata
+#include <Enumerations.h>
 
 class AlignmentContext {
 public:

--- a/alignment/datastructures/alignment/ByteAlignment.h
+++ b/alignment/datastructures/alignment/ByteAlignment.h
@@ -1,8 +1,8 @@
 #ifndef DATASTRUCTURES_ALIGNMENT_BYTE_ALIGNMENT_H_
 #define DATASTRUCTURES_ALIGNMENT_BYTE_ALIGNMENT_H_
 #include <vector>
-#include "algorithms/alignment/AlignmentUtils.hpp"
-#include "DNASequence.hpp"
+#include "../algorithms/alignment/AlignmentUtils.hpp"
+#include <DNASequence.hpp> // pbdata
 
 using namespace std;
 /*

--- a/alignment/datastructures/alignment/CmpFile.hpp
+++ b/alignment/datastructures/alignment/CmpFile.hpp
@@ -1,14 +1,15 @@
 #ifndef _BLASR_CMP_FILE_HPP_
 #define _BLASR_CMP_FILE_HPP_
 
-#include "reads/ReadType.hpp"
-#include "datastructures/alignment/CmpIndexedStringTable.h"
-#include "saf/AlnGroup.hpp"
-#include "saf/AlnInfo.hpp"
-#include "saf/RefGroup.hpp"
-#include "saf/RefInfo.hpp"
-#include "saf/MovieInfo.hpp"
-#include "Enumerations.h"
+#include "CmpIndexedStringTable.h"
+// pbdata
+#include <reads/ReadType.hpp>
+#include <saf/AlnGroup.hpp>
+#include <saf/AlnInfo.hpp>
+#include <saf/RefGroup.hpp>
+#include <saf/RefInfo.hpp>
+#include <saf/MovieInfo.hpp>
+#include <Enumerations.h>
 
 #include <vector>
 

--- a/alignment/datastructures/alignment/SAMToAlignmentCandidateAdapter.cpp
+++ b/alignment/datastructures/alignment/SAMToAlignmentCandidateAdapter.cpp
@@ -1,5 +1,5 @@
 #include <algorithm>
-#include "utils/SMRTTitle.hpp"
+#include <utils/SMRTTitle.hpp> // pbdata
 #include "SAMToAlignmentCandidateAdapter.hpp"
 
 void InitializeCandidateFromSAM(SAMAlignment &sam,

--- a/alignment/datastructures/alignment/SAMToAlignmentCandidateAdapter.hpp
+++ b/alignment/datastructures/alignment/SAMToAlignmentCandidateAdapter.hpp
@@ -2,10 +2,11 @@
 #define _BLASR_SAM_TO_ALIGNMENT_CANDIDATE_ADAPTER_HPP_
 
 #include <map>
+// pbdata
+#include <sam/SAMAlignment.hpp>
+#include <sam/SAMFlag.h>
 
-#include "sam/SAMAlignment.hpp"
-#include "sam/SAMFlag.h"
-#include "datastructures/alignment/AlignmentCandidate.hpp"
+#include "AlignmentCandidate.hpp"
 
 void InitializeCandidateFromSAM(SAMAlignment &sam,
                                 AlignmentCandidate<> &candidate);

--- a/alignment/datastructures/alignmentset/AlignmentSetToCmpH5Adapter.hpp
+++ b/alignment/datastructures/alignmentset/AlignmentSetToCmpH5Adapter.hpp
@@ -1,12 +1,12 @@
 #ifndef _BLASR_ALIGNMENT_SET_TO_CMPH5_ADAPTER_HPP_
 #define _BLASR_ALIGNMENT_SET_TO_CMPH5_ADAPTER_HPP_
 
-#include "utils/SMRTReadUtils.hpp"
-#include "HDFCmpFile.hpp"
-#include "sam/AlignmentSet.hpp"
+#include <utils/SMRTReadUtils.hpp> // pbdata
+#include <sam/AlignmentSet.hpp> // pbdata
+#include <HDFCmpFile.hpp> // hdf
 #include "datastructures/alignment/AlignmentCandidate.hpp"
 #include "datastructures/alignment/ByteAlignment.h"
-#include "algorithms/alignment/DistanceMatrixScoreFunction.hpp"
+#include "../../algorithms/alignment/DistanceMatrixScoreFunction.hpp"
 
 class RefGroupNameId {
  public:

--- a/alignment/datastructures/alignmentset/SAMQVConversion.cpp
+++ b/alignment/datastructures/alignmentset/SAMQVConversion.cpp
@@ -1,6 +1,6 @@
 #include <cstddef>
 #include <assert.h>
-#include "FASTQSequence.hpp"
+#include <FASTQSequence.hpp> // pbdata
 #include "SAMQVConversion.hpp"
 
 void QualityVectorToPrintable(unsigned char *data, int length) {

--- a/alignment/datastructures/alignmentset/SAMSupplementalQVList.hpp
+++ b/alignment/datastructures/alignmentset/SAMSupplementalQVList.hpp
@@ -1,6 +1,6 @@
 #ifndef _BLASR_SAMSUPPLEMENTALQVLIST_HPP_
 #define _BLASR_SAMSUPPLEMENTALQVLIST_HPP_
-#include "SMRTSequence.hpp"
+#include <SMRTSequence.hpp> // pbdata
 #include "SAMQVConversion.hpp"
 
 class SupplementalQVList {

--- a/alignment/datastructures/anchoring/AnchorParameters.hpp
+++ b/alignment/datastructures/anchoring/AnchorParameters.hpp
@@ -3,8 +3,8 @@
 
 #include <fstream>
 #include <iostream>
-#include "qvs/QualityValue.hpp"
-#include "DNASequence.hpp"
+#include <qvs/QualityValue.hpp> // pbdata
+#include <DNASequence.hpp> // pbdata
 
 class AnchorParameters {
 public:

--- a/alignment/datastructures/anchoring/ClusterList.cpp
+++ b/alignment/datastructures/anchoring/ClusterList.cpp
@@ -1,4 +1,4 @@
-#include "datastructures/anchoring/ClusterList.hpp"
+#include "ClusterList.hpp"
 
 ClusterList::ClusterList() {
     lowerSizeLimit = 20;

--- a/alignment/datastructures/anchoring/ClusterList.hpp
+++ b/alignment/datastructures/anchoring/ClusterList.hpp
@@ -2,7 +2,7 @@
 #define _BLASR_CLUSTER_LIST_HPP_
 
 #include <vector>
-#include "DNASequence.hpp"
+#include <DNASequence.hpp> // pbdata
 
 class ClusterList {
 public:

--- a/alignment/datastructures/anchoring/MatchPos.hpp
+++ b/alignment/datastructures/anchoring/MatchPos.hpp
@@ -4,8 +4,8 @@
 #include <vector>
 #include <algorithm>
 #include <ostream>
-#include "Types.h"
-#include "DNASequence.hpp"
+#include <Types.h> // pbdata
+#include <DNASequence.hpp> // pbdata
 
 class MatchPos {
 public:

--- a/alignment/datastructures/anchoring/WeightedInterval.cpp
+++ b/alignment/datastructures/anchoring/WeightedInterval.cpp
@@ -1,4 +1,4 @@
-#include "datastructures/anchoring/WeightedInterval.hpp"
+#include "WeightedInterval.hpp"
 
 WeightedInterval::WeightedInterval(){}
 

--- a/alignment/datastructures/anchoring/WeightedInterval.hpp
+++ b/alignment/datastructures/anchoring/WeightedInterval.hpp
@@ -3,8 +3,8 @@
 
 #include <vector>
 #include <set>
-#include "DNASequence.hpp"
-#include "datastructures/anchoring/MatchPos.hpp" 
+#include <DNASequence.hpp> // pbdata
+#include "MatchPos.hpp"
 
 class WeightedInterval {
 public:

--- a/alignment/files/BaseSequenceIO.hpp
+++ b/alignment/files/BaseSequenceIO.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <iostream>
 #include <cassert>
-#include "Enumerations.h"
+#include <Enumerations.h> // pbdata
 
 class BaseSequenceIO {
 

--- a/alignment/files/CCSIterator.cpp
+++ b/alignment/files/CCSIterator.cpp
@@ -1,4 +1,4 @@
-#include "files/CCSIterator.hpp"
+#include "CCSIterator.hpp"
 
 void CCSIterator::Initialize(CCSSequence *_seqPtr) {
     seqPtr = _seqPtr;

--- a/alignment/files/FragmentCCSIterator.cpp
+++ b/alignment/files/FragmentCCSIterator.cpp
@@ -1,4 +1,4 @@
-#include "files/FragmentCCSIterator.hpp"
+#include "FragmentCCSIterator.hpp"
 
 
 void FragmentCCSIterator::

--- a/alignment/files/FragmentCCSIterator.hpp
+++ b/alignment/files/FragmentCCSIterator.hpp
@@ -2,9 +2,9 @@
 #define _BLASR_FRAGMENT_CCS_ITERATOR_HPP_
 
 #include <vector>
-#include "reads/RegionTable.hpp"
-#include "utils/RegionUtils.hpp"
-#include "files/CCSIterator.hpp"
+#include <reads/RegionTable.hpp> // pbdata
+#include "../utils/RegionUtils.hpp"
+#include "CCSIterator.hpp"
 
 
 class FragmentCCSIterator : public CCSIterator {

--- a/alignment/files/ReaderAgglomerate.cpp
+++ b/alignment/files/ReaderAgglomerate.cpp
@@ -1,4 +1,4 @@
-#include "files/ReaderAgglomerate.hpp"
+#include "ReaderAgglomerate.hpp"
 
 void ReaderAgglomerate::SetToUpper() {
     fastaReader.SetToUpper();

--- a/alignment/files/ReaderAgglomerate.hpp
+++ b/alignment/files/ReaderAgglomerate.hpp
@@ -2,28 +2,27 @@
 #define _BLASR_READER_AGGLOMERATE_HPP_
 
 #include <cstdlib>
+// pbdata
+#include <Enumerations.h>
+#include <reads/ReadType.hpp>
+#include <FASTAReader.hpp>
+#include <FASTQReader.hpp>
+#include <CCSSequence.hpp>
+#include <SMRTSequence.hpp>
+#include <StringUtils.hpp>
+// hdf
+#include <HDFBasReader.hpp>
+#include <HDFCCSReader.hpp>
 
-#include "Enumerations.h"
-#include "reads/ReadType.hpp"
-#include "files/BaseSequenceIO.hpp"
-
-#include "FASTAReader.hpp"
-#include "FASTQReader.hpp"
-#include "CCSSequence.hpp"
-#include "SMRTSequence.hpp"
-#include "StringUtils.hpp"
-
-#include "HDFBasReader.hpp"
-#include "HDFCCSReader.hpp"
-
+#include "BaseSequenceIO.hpp"
 #ifdef USE_PBBAM
-#include "pbbam/DataSet.h"
-#include "pbbam/EntireFileQuery.h"
-#include "pbbam/PbiFilter.h"
-#include "pbbam/PbiFilterQuery.h"
-#include "query/SequentialZmwGroupQuery.h"
-#include "query/PbiFilterZmwGroupQuery.h"
-#include "pbbam/BamRecord.h"
+#include <pbbam/DataSet.h>
+#include <pbbam/EntireFileQuery.h>
+#include <pbbam/PbiFilter.h>
+#include <pbbam/PbiFilterQuery.h>
+#include "../query/SequentialZmwGroupQuery.h"
+#include "../query/PbiFilterZmwGroupQuery.h"
+#include <pbbam/BamRecord.h>
 #endif
 
 class ReaderAgglomerate : public BaseSequenceIO {
@@ -142,6 +141,6 @@ int ReadChunkByNReads(ReaderAgglomerate &reader, vector<T_Sequence> &reads, int 
 template<typename T_Sequence>
 int ReadChunkBySize (ReaderAgglomerate &reader, vector<T_Sequence> &reads, int maxMemorySize);
 
-#include "files/ReaderAgglomerateImpl.hpp"
+#include "ReaderAgglomerateImpl.hpp"
 
 #endif

--- a/alignment/format/BAMPrinter.hpp
+++ b/alignment/format/BAMPrinter.hpp
@@ -4,9 +4,9 @@
 #ifdef USE_PBBAM
 #include <sstream>
 #include <stdint.h>
-#include "format/SAMPrinter.hpp"
-#include "pbbam/BamHeader.h"
-#include "pbbam/BamWriter.h"
+#include "SAMPrinter.hpp"
+#include <pbbam/BamHeader.h>
+#include <pbbam/BamWriter.h>
 
 template<typename T_Sequence>
 void AlignmentToBamRecord(T_AlignmentCandidate & alignment, 

--- a/alignment/format/BAMPrinterImpl.hpp
+++ b/alignment/format/BAMPrinterImpl.hpp
@@ -4,11 +4,11 @@
 #ifdef USE_PBBAM
 
 #include <algorithm>
-#include "utils/SMRTTitle.hpp"
+#include <utils/SMRTTitle.hpp> // pbdata
 using namespace BAMOutput;
 using namespace std;
-#include "pbbam/BamRecord.h"
-#include "pbbam/BamFile.h"
+#include <pbbam/BamRecord.h>
+#include <pbbam/BamFile.h>
 
 template<typename T_Sequence>
 void AlignmentToBamRecord(T_AlignmentCandidate & alignment, 

--- a/alignment/format/CompareSequencesPrinter.hpp
+++ b/alignment/format/CompareSequencesPrinter.hpp
@@ -3,7 +3,7 @@
 
 #include <fstream>
 #include <iostream>
-#include "algorithms/alignment/AlignmentUtils.hpp"
+#include "../algorithms/alignment/AlignmentUtils.hpp"
 
 namespace CompareSequencesOutput{
 

--- a/alignment/format/IntervalPrinter.hpp
+++ b/alignment/format/IntervalPrinter.hpp
@@ -1,8 +1,8 @@
 #ifndef _BLASR_INTERVAL_ALIGNMENT_PRINTER_HPP_
 #define _BLASR_INTERVAL_ALIGNMENT_PRINTER_HPP_
 
-#include "datastructures/alignment/AlignmentCandidate.hpp"
-#include "FASTQSequence.hpp"
+#include "../datastructures/alignment/AlignmentCandidate.hpp"
+#include <FASTQSequence.hpp> // pbdata
 
 namespace IntervalOutput{
 

--- a/alignment/format/SAMHeaderPrinter.cpp
+++ b/alignment/format/SAMHeaderPrinter.cpp
@@ -1,5 +1,5 @@
 #include <assert.h>
-#include "format/SAMHeaderPrinter.hpp"
+#include "SAMHeaderPrinter.hpp"
 
 const std::string SAMVERSION("1.5");
 const std::string PBBAMVERSION("3.0.1");

--- a/alignment/format/SAMHeaderPrinter.hpp
+++ b/alignment/format/SAMHeaderPrinter.hpp
@@ -6,12 +6,12 @@
 #include <set>
 #include <iostream>
 #include <sstream>
-#include "Types.h"
-#include "Enumerations.h"
-#include "StringUtils.hpp"
-#include "files/BaseSequenceIO.hpp"
-#include "files/ReaderAgglomerate.hpp"
-#include "datastructures/alignmentset/SAMSupplementalQVList.hpp"
+#include <Types.h> // pbdata
+#include <Enumerations.h> // pbdata
+#include <StringUtils.hpp> // pbdata
+#include "../files/BaseSequenceIO.hpp"
+#include "../files/ReaderAgglomerate.hpp"
+#include "../datastructures/alignmentset/SAMSupplementalQVList.hpp"
 
 /// This is a simple implementation for generating SAM Headers. 
 /// It is provided such that libblasr can compile with and without

--- a/alignment/format/SAMPrinter.hpp
+++ b/alignment/format/SAMPrinter.hpp
@@ -3,12 +3,12 @@
 
 #include <sstream>
 #include <stdint.h>
-#include "SMRTSequence.hpp"
-#include "datastructures/alignment/AlignmentCandidate.hpp"
-#include "datastructures/alignment/AlignmentContext.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "datastructures/alignmentset/SAMSupplementalQVList.hpp"
+#include <SMRTSequence.hpp> // pbdata
+#include "../datastructures/alignment/AlignmentCandidate.hpp"
+#include "../datastructures/alignment/AlignmentContext.hpp"
+#include "../datastructures/alignment/Alignment.hpp"
+#include "../datastructures/alignment/Alignment.hpp"
+#include "../datastructures/alignmentset/SAMSupplementalQVList.hpp"
 
 
 #define MULTI_SEGMENTS 0x1

--- a/alignment/format/StickAlignmentPrinter.hpp
+++ b/alignment/format/StickAlignmentPrinter.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-#include "datastructures/alignment/Alignment.hpp"
-#include "algorithms/alignment/AlignmentUtils.hpp"
+#include "../datastructures/alignment/Alignment.hpp"
+#include "../algorithms/alignment/AlignmentUtils.hpp"
 
 template<typename T_Alignment, typename T_QuerySequence, typename T_TargetSequence>
 void StickPrintAlignment(T_Alignment &alignment, 

--- a/alignment/format/SummaryPrinter.hpp
+++ b/alignment/format/SummaryPrinter.hpp
@@ -1,8 +1,8 @@
 #ifndef SUMMARY_ALIGNMENT_PRINTER_H_
 #define SUMMARY_ALIGNMENT_PRINTER_H_
 
-#include "datastructures/alignment/AlignmentCandidate.hpp"
-#include "FASTQSequence.hpp"
+#include "../datastructures/alignment/AlignmentCandidate.hpp"
+#include <FASTQSequence.hpp> // pbdata
 
 namespace SummaryOutput{
 

--- a/alignment/makefile
+++ b/alignment/makefile
@@ -5,7 +5,7 @@ THISDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include ${THISDIR}/../rules.mk
 
 CXXOPTS  := -std=c++11 -pedantic -Wno-long-long -Wall -Wextra
-INCLUDES += ${THISDIR} ${LIBPBIHDF_INC} ${LIBPBDATA_INC}
+INCLUDES += ${LIBPBIHDF_INC} ${LIBPBDATA_INC}
 SYSINCLUDES = ${HDF5_INC} ${PBBAM_INC} ${HTSLIB_INC} ${BOOST_INC}
 LIBS     += ${LIBPBDATA_LIB} ${LIBPBIHDF_LIB} ${HDF5_LIB} ${PBBAM_LIB} ${HTSLIB_LIB} ${ZLIB_LIB}
 LDFLAGS  += $(patsubst %,-L%,${LIBS})

--- a/alignment/query/PbiFilterZmwGroupQuery.cpp
+++ b/alignment/query/PbiFilterZmwGroupQuery.cpp
@@ -1,7 +1,7 @@
-#include "libconfig.h"
+#include <libconfig.h>
 #ifdef USE_PBBAM
 #include "PbiFilterZmwGroupQuery.h"
-#include "pbbam/CompositeBamReader.h"
+#include <pbbam/CompositeBamReader.h>
 #include <boost/optional.hpp>
 #include <cassert>
 using namespace PacBio;

--- a/alignment/query/PbiFilterZmwGroupQuery.h
+++ b/alignment/query/PbiFilterZmwGroupQuery.h
@@ -1,10 +1,10 @@
-#include "libconfig.h"
+#include <libconfig.h>
 #ifdef USE_PBBAM
 #ifndef PBIFILTER_ZMWGROUPQUERY_H 
 #define PBIFILTER_ZMWGROUPQUERY_H
 
-#include "pbbam/internal/QueryBase.h"
-#include "pbbam/PbiFilter.h"
+#include <pbbam/internal/QueryBase.h>
+#include <pbbam/PbiFilter.h>
 #include <memory>
 
 namespace PacBio {

--- a/alignment/query/SequentialZmwGroupQuery.cpp
+++ b/alignment/query/SequentialZmwGroupQuery.cpp
@@ -1,7 +1,7 @@
-#include "libconfig.h"
+#include <libconfig.h>
 #ifdef USE_PBBAM
 #include "SequentialZmwGroupQuery.h"
-#include "pbbam/CompositeBamReader.h"
+#include <pbbam/CompositeBamReader.h>
 #include <boost/optional.hpp>
 #include <cassert>
 using namespace PacBio;

--- a/alignment/query/SequentialZmwGroupQuery.h
+++ b/alignment/query/SequentialZmwGroupQuery.h
@@ -1,9 +1,9 @@
-#include "libconfig.h"
+#include <libconfig.h>
 #ifdef USE_PBBAM
 #ifndef SEQUENTIAL_ZMWGROUPQUERY_H
 #define SEQUENTIAL_ZMWGROUPQUERY_H
 
-#include "pbbam/internal/QueryBase.h"
+#include <pbbam/internal/QueryBase.h>
 #include <memory>
 
 namespace PacBio {

--- a/alignment/qvs/QualityValueProfile.hpp
+++ b/alignment/qvs/QualityValueProfile.hpp
@@ -1,11 +1,11 @@
 #ifndef _BLASR_QUALITY_VALUE_PROFILE_HPP_
 #define _BLASR_QUALITY_VALUE_PROFILE_HPP_
 
+#include "../tuples/DNATuple.hpp"
+#include "../tuples/TupleMetrics.hpp"
 #include <fstream>
-#include "tuples/DNATuple.hpp"
-#include "tuples/TupleMetrics.hpp"
-#include "matrix/FlatMatrix.hpp"
-#include "qvs/QualityValue.hpp"
+#include <qvs/QualityValue.hpp> // pbdata
+#include <matrix/FlatMatrix.hpp> // pbdata
 
 class QualityValueProfile {
 	int wordSize;

--- a/alignment/simulator/CDFMap.hpp
+++ b/alignment/simulator/CDFMap.hpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <vector>
 #include <assert.h>
-#include "statistics/StatUtils.hpp"
+#include "../statistics/StatUtils.hpp"
 
 template<typename T_Data>
 class CDFMap {

--- a/alignment/simulator/ContextOutputList.hpp
+++ b/alignment/simulator/ContextOutputList.hpp
@@ -6,8 +6,8 @@
 #include <iostream>
 #include <fstream>
 #include <string>
-#include "utils.hpp"
-#include "simulator/OutputList.hpp"
+#include <utils.hpp> // pbdata
+#include "OutputList.hpp"
 
 
 class ContextOutputList {

--- a/alignment/simulator/ContextSample.hpp
+++ b/alignment/simulator/ContextSample.hpp
@@ -4,8 +4,8 @@
 #include<string>
 #include<vector>
 #include<iostream>
-#include "simulator/QualitySample.hpp"
-#include "statistics/StatUtils.hpp"
+#include "QualitySample.hpp"
+#include "../statistics/StatUtils.hpp"
 
 class ContextSample {
 public:

--- a/alignment/simulator/LengthHistogram.cpp
+++ b/alignment/simulator/LengthHistogram.cpp
@@ -1,4 +1,4 @@
-#include "simulator/LengthHistogram.hpp"
+#include "LengthHistogram.hpp"
 
 int LengthHistogram::Read(std::string &inName) {
     std::ifstream in;

--- a/alignment/simulator/LengthHistogram.hpp
+++ b/alignment/simulator/LengthHistogram.hpp
@@ -4,9 +4,9 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include "simulator/CDFMap.hpp"
-#include "alignment/CmpAlignment.hpp"
-#include "utils.hpp"
+#include "CDFMap.hpp"
+#include <alignment/CmpAlignment.hpp> // pbdata
+#include <utils.hpp> // pbdata
 
 class LengthHistogram {
 public:

--- a/alignment/simulator/OutputSample.hpp
+++ b/alignment/simulator/OutputSample.hpp
@@ -2,7 +2,7 @@
 #define _SIMULATOR_OUTPUT_SAMPLE_HPP_
 
 #include "QualitySample.hpp"
-#include "SMRTSequence.hpp"
+#include <SMRTSequence.hpp> // pbdata
 
 class OutputSample {
 public:

--- a/alignment/simulator/OutputSampleListSet.hpp
+++ b/alignment/simulator/OutputSampleListSet.hpp
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 #include <iostream>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 #include "OutputSampleList.hpp"
 
 

--- a/alignment/simulator/QualitySample.hpp
+++ b/alignment/simulator/QualitySample.hpp
@@ -2,9 +2,9 @@
 #define _SIMULATOR_QUALITY_SAMPLE_HPP_
 
 #include <iostream>
-#include "Types.h"
-#include "SMRTSequence.hpp"
-#include "qvs/QualityValue.hpp"
+#include <Types.h> // pbdata
+#include <qvs/QualityValue.hpp> // pbdata
+#include <SMRTSequence.hpp> // pbdata
 
 #define NQV 4
 #define NFV 3

--- a/alignment/statistics/LookupAnchorDistribution.cpp
+++ b/alignment/statistics/LookupAnchorDistribution.cpp
@@ -1,4 +1,4 @@
-#include "statistics/LookupAnchorDistribution.hpp"
+#include "LookupAnchorDistribution.hpp"
 
 int LookupAnchorDistribution(int readLength, int minMatchLength, 
     int accuracy, float &mn, float &sdn, float &mnab, 

--- a/alignment/statistics/LookupAnchorDistribution.hpp
+++ b/alignment/statistics/LookupAnchorDistribution.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_LOOKUP_ANCHOR_DISTRIBUTION_HPP_
 #define _BLASR_LOOKUP_ANCHOR_DISTRIBUTION_HPP_
 
-#include "statistics/AnchorDistributionTable.hpp" // not ported
+#include "AnchorDistributionTable.hpp" // not ported
 
 int LookupAnchorDistribution(int readLength, int minMatchLength, 
     int accuracy, float &mn, float &sdn, float &mnab, 

--- a/alignment/statistics/VarianceAccumulator.hpp
+++ b/alignment/statistics/VarianceAccumulator.hpp
@@ -23,6 +23,6 @@ public:
     void Append(T v);
 };
 
-#include "statistics/VarianceAccumulatorImpl.hpp"
+#include "VarianceAccumulatorImpl.hpp"
 
 #endif

--- a/alignment/suffixarray/LCPTable.hpp
+++ b/alignment/suffixarray/LCPTable.hpp
@@ -3,7 +3,7 @@
 
 #include <map>
 #include <fstream>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 
 template <typename T>
 class LCPTable {

--- a/alignment/suffixarray/SharedSuffixArray.hpp
+++ b/alignment/suffixarray/SharedSuffixArray.hpp
@@ -5,10 +5,10 @@
 #include <fstream>
 #include <sstream>
 #include "SuffixArray.hpp"
-#include "ipc/SharedMemoryAllocator.hpp"
-#include "tuples/DNATuple.hpp"
-#include "tuples/CompressedDNATuple.hpp"
-#include "algorithms/compare/CompareStrings.hpp"
+#include "../ipc/SharedMemoryAllocator.hpp"
+#include "../tuples/DNATuple.hpp"
+#include "../tuples/CompressedDNATuple.hpp"
+#include "../algorithms/compare/CompareStrings.hpp"
 
 
 template<typename T, 

--- a/alignment/suffixarray/SuffixArray.hpp
+++ b/alignment/suffixarray/SuffixArray.hpp
@@ -7,17 +7,17 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <defs.h> // pbdata
+#include <utils.hpp> // pbdata
+#include <qvs/QualityValue.hpp> // pbdata
+#include <DNASequence.hpp> // pbdata
+#include <NucConversion.hpp> // pbdata
 #include "LCPTable.hpp"
-#include "defs.h"
-#include "utils.hpp"
-#include "tuples/DNATuple.hpp"
-#include "tuples/CompressedDNATuple.hpp"
-#include "qvs/QualityValue.hpp"
-#include "DNASequence.hpp"
-#include "NucConversion.hpp"
-#include "algorithms/compare/CompareStrings.hpp"
-#include "algorithms/sorting/qsufsort.hpp"
-#include "algorithms/sorting/LightweightSuffixArray.hpp"
+#include "../algorithms/compare/CompareStrings.hpp"
+#include "../algorithms/sorting/qsufsort.hpp"
+#include "../algorithms/sorting/LightweightSuffixArray.hpp"
+#include "../tuples/DNATuple.hpp"
+#include "../tuples/CompressedDNATuple.hpp"
 /*
  * Suffix array implementation, with a Manber and Meyers sort, but
  * that is typically not used.

--- a/alignment/suffixarray/SuffixArrayTypes.hpp
+++ b/alignment/suffixarray/SuffixArrayTypes.hpp
@@ -7,7 +7,7 @@
 
 #include "CompressedSequence.hpp"
 #include "Compare4BitCompressed.hpp"
-#include "FASTASequence.hpp"
+#include <FASTASequence.hpp> // pbdata
 
 typedef SuffixArray<Nucleotide, std::vector<int> > DNASuffixArray;
 typedef SuffixArray<Nucleotide, std::vector<int>, 

--- a/alignment/suffixarray/ssort.hpp
+++ b/alignment/suffixarray/ssort.hpp
@@ -234,7 +234,7 @@ Bad input
 */
 
 #include <stdlib.h>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 
 enum {
 	ORIG = ~(~0u>>1),			/* sign bit */

--- a/alignment/tuples/BaseTuple.cpp
+++ b/alignment/tuples/BaseTuple.cpp
@@ -1,5 +1,5 @@
 #include <stdint.h>
-#include "Types.h"
+#include <Types.h> // pbdata
 #include "TupleMask.h"
 #include "TupleMetrics.hpp"
 #include "BaseTuple.hpp"

--- a/alignment/tuples/BaseTuple.hpp
+++ b/alignment/tuples/BaseTuple.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_BASE_TUPLE_HPP_
 #define _BLASR_BASE_TUPLE_HPP_
 
-#include "tuples/TupleMetrics.hpp"
+#include "TupleMetrics.hpp"
 
 class BaseTuple {
 public:

--- a/alignment/tuples/DNATuple.cpp
+++ b/alignment/tuples/DNATuple.cpp
@@ -1,4 +1,4 @@
-#include "tuples/DNATuple.hpp"
+#include "DNATuple.hpp"
 
 
 int DNATuple::FromStringRL(Nucleotide *strPtr, TupleMetrics &tm) {

--- a/alignment/tuples/DNATuple.hpp
+++ b/alignment/tuples/DNATuple.hpp
@@ -6,14 +6,14 @@
 #include <stdint.h>
 #include <ostream>
 #include <string>
-#include "Types.h"
-#include "SeqUtils.hpp"
-#include "DNASequence.hpp"
-#include "NucConversion.hpp"
-#include "tuples/BaseTuple.hpp"
-#include "tuples/TupleMetrics.hpp"
-#include "tuples/TupleList.hpp"
-#include "tuples/TupleOperations.h"
+#include <Types.h> // pbdata
+#include <SeqUtils.hpp> // pbdata
+#include <DNASequence.hpp> // pbdata
+#include <NucConversion.hpp> // pbdata
+#include "BaseTuple.hpp"
+#include "TupleMetrics.hpp"
+#include "TupleList.hpp"
+#include "TupleOperations.h"
 
 class DNATuple : public BaseTuple {
 public:

--- a/alignment/tuples/DNATupleImpl.hpp
+++ b/alignment/tuples/DNATupleImpl.hpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#include "NucConversion.hpp"
+#include <NucConversion.hpp> // pbdata
 
 inline int DNATuple::FromStringLR(Nucleotide *strPtr, TupleMetrics &tm) {
     DNASequence tmpSeq;

--- a/alignment/tuples/HashedTupleList.hpp
+++ b/alignment/tuples/HashedTupleList.hpp
@@ -1,9 +1,9 @@
 #ifndef _BLASR_HASHED_TUPLE_LIST_HPP_
 #define _BLASR_HASHED_TUPLE_LIST_HPP_
 
-#include "tuples/TupleList.hpp"
-#include "tuples/TupleMetrics.hpp"
-#include "DNASequence.hpp"
+#include "TupleList.hpp"
+#include "TupleMetrics.hpp"
+#include <DNASequence.hpp> // pbdata
 
 template<typename T_Tuple>
 class HashedTupleList {

--- a/alignment/tuples/TupleCountTable.hpp
+++ b/alignment/tuples/TupleCountTable.hpp
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include <assert.h>
-#include "tuples/TupleMetrics.hpp"
+#include "TupleMetrics.hpp"
 using namespace std;
 
 template<typename TSequence, typename TTuple>
@@ -28,6 +28,6 @@ public:
 	void Read(ifstream &in);
 };
 
-#include "tuples/TupleCountTableImpl.hpp"
+#include "TupleCountTableImpl.hpp"
 
 #endif

--- a/alignment/tuples/TupleCountTableImpl.hpp
+++ b/alignment/tuples/TupleCountTableImpl.hpp
@@ -1,6 +1,6 @@
 #ifndef _BLASR_TUPLE_COUNT_TABLE_IMPL_HPP_
 #define _BLASR_TUPLE_COUNT_TABLE_IMPL_HPP_
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 
 using namespace std;
 

--- a/alignment/tuples/TupleList.hpp
+++ b/alignment/tuples/TupleList.hpp
@@ -8,8 +8,8 @@
 #include <fstream>
 #include <vector>
 
-#include "Types.h"
-#include "tuples/TupleMetrics.hpp"
+#include <Types.h> // pbdata
+#include "TupleMetrics.hpp"
 
 template<typename T>
 class TupleList {

--- a/alignment/tuples/TupleMatching.hpp
+++ b/alignment/tuples/TupleMatching.hpp
@@ -1,11 +1,11 @@
 #ifndef _BLASR_TUPLE_MATCHING_HPP_
 #define _BLASR_TUPLE_MATCHING_HPP_
 
-#include "tuples/TupleMetrics.hpp"
-#include "tuples/TupleList.hpp"
-#include "tuples/BaseTuple.hpp"
-#include "tuples/DNATuple.hpp"
-#include "tuples/TupleMatching.hpp"
+#include "TupleMetrics.hpp"
+#include "TupleList.hpp"
+#include "BaseTuple.hpp"
+#include "DNATuple.hpp"
+#include "TupleMatching.hpp"
 
 template<typename Sequence, typename T_TupleList> 
 int SequenceToTupleList(

--- a/alignment/tuples/TupleMatchingImpl.hpp
+++ b/alignment/tuples/TupleMatchingImpl.hpp
@@ -3,10 +3,10 @@
 #include <utility>
 #include <iostream>
 #include <stdint.h>
-#include "Types.h"
-#include "NucConversion.hpp"
-#include "DNASequence.hpp"
-#include "SeqUtils.hpp"
+#include <Types.h> // pbdata
+#include <NucConversion.hpp> // pbdata
+#include <DNASequence.hpp> // pbdata
+#include <SeqUtils.hpp> // pbdata
 
 using namespace std;
 

--- a/alignment/tuples/TupleMetrics.hpp
+++ b/alignment/tuples/TupleMetrics.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_TUPLE_METRICS_HPP_
 #define _BLASR_TUPLE_METRICS_HPP_
 
-#include "Types.h"
+#include <Types.h> // pbdata
 
 class TupleMetrics {
 public:

--- a/alignment/tuples/tuple.h
+++ b/alignment/tuples/tuple.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <utility>
 
-#include "Types.h"
+#include <Types.h> // pbdata
 #include "tuples/TupleMetrics.hpp"
 
 template<typename Sequence, typename Tuple>

--- a/alignment/utils/FileOfFileNames.cpp
+++ b/alignment/utils/FileOfFileNames.cpp
@@ -1,5 +1,5 @@
-#include "utils/FileOfFileNames.hpp"
-#include "HDFNewBasReader.hpp"
+#include "FileOfFileNames.hpp"
+#include <HDFNewBasReader.hpp> // hdf
 #include <cstdlib>
 
 void

--- a/alignment/utils/FileOfFileNames.hpp
+++ b/alignment/utils/FileOfFileNames.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 #include <fstream>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 
 class FileOfFileNames {
 public:

--- a/alignment/utils/FileUtils.cpp
+++ b/alignment/utils/FileUtils.cpp
@@ -1,4 +1,4 @@
-#include "utils/FileUtils.hpp"
+#include "FileUtils.hpp"
 
 using namespace std;
 

--- a/alignment/utils/FileUtils.hpp
+++ b/alignment/utils/FileUtils.hpp
@@ -4,8 +4,8 @@
 #include <iostream>
 #include <fstream>
 #include <string>
-#include "sys/fcntl.h"
-#include "sys/mman.h"
+#include <sys/fcntl.h>
+#include <sys/mman.h>
 #include <sys/types.h> // for lseek
 #include <unistd.h> // for lseek
 #include <stdio.h>

--- a/alignment/utils/RangeUtils.hpp
+++ b/alignment/utils/RangeUtils.hpp
@@ -18,8 +18,8 @@
  */
 #include <stdlib.h>
 #include <algorithm>
-#include "StringUtils.hpp"
-#include "Types.h"
+#include <StringUtils.hpp> // pbdata
+#include <Types.h> // pbdata
 
 class Range {
 public:

--- a/alignment/utils/RegionUtils.cpp
+++ b/alignment/utils/RegionUtils.cpp
@@ -1,4 +1,4 @@
-#include "utils/RegionUtils.hpp"
+#include "RegionUtils.hpp"
 
 // General functions.
 bool LookupHQRegion(int holeNumber, RegionTable &regionTable, 

--- a/alignment/utils/RegionUtils.hpp
+++ b/alignment/utils/RegionUtils.hpp
@@ -3,10 +3,10 @@
 
 #include <algorithm>
 #include <cmath>
-#include "SMRTSequence.hpp"
-#include "statistics/StatUtils.hpp"
-#include "reads/ReadInterval.hpp"
-#include "reads/RegionTable.hpp"
+#include <SMRTSequence.hpp>
+#include <reads/ReadInterval.hpp>
+#include <reads/RegionTable.hpp>
+#include "../statistics/StatUtils.hpp"
 
 bool LookupHQRegion(int holeNumber, RegionTable &regionTable, 
     int &start, int &end, int &score);
@@ -79,6 +79,6 @@ void CreateDirections(std::vector<int> & directions, const int & n);
 // Flop all directions in the given vector, if flop is true.
 void UpdateDirections(std::vector<int> & directions, bool flop = false);
 
-#include "utils/RegionUtilsImpl.hpp"
+#include "RegionUtilsImpl.hpp"
 
 #endif

--- a/hdf/BufferedHDF2DArray.hpp
+++ b/hdf/BufferedHDF2DArray.hpp
@@ -5,9 +5,9 @@
 #include <iostream>
 #include <string>
 
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 
-#include "Types.h"
+#include <Types.h> // pbdata
 #include "HDFConfig.hpp"
 #include "HDFData.hpp"
 #include "HDFGroup.hpp"

--- a/hdf/BufferedHDF2DArrayImpl.hpp
+++ b/hdf/BufferedHDF2DArrayImpl.hpp
@@ -3,7 +3,7 @@
 
 #include <cstring>
 #include <cassert>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 
 template<typename T>
 BufferedHDF2DArray<T>::BufferedHDF2DArray(H5::CommonFG *_container, 

--- a/hdf/BufferedHDFArray.hpp
+++ b/hdf/BufferedHDFArray.hpp
@@ -7,17 +7,17 @@
 #include <vector>
 
 // HDF5 library includes
-#include "hdf5.h"
-#include "H5Cpp.h"
+#include <hdf5.h>
+#include <H5Cpp.h>
 
-#include "Types.h"
+#include <Types.h> // pbdata
 #include "HDFConfig.hpp"
 #include "HDFData.hpp"
 #include "HDFGroup.hpp"
 #include "HDFWriteBuffer.hpp"
 #include "HDFFile.hpp"
-#include "DNASequence.hpp"
-#include "FASTQSequence.hpp"
+#include <DNASequence.hpp> // pbdata
+#include <FASTQSequence.hpp> // pbdata
 
 /*
  *

--- a/hdf/BufferedHDFArrayImpl.hpp
+++ b/hdf/BufferedHDFArrayImpl.hpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <cstring>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata
 #include "BufferedHDFArray.hpp"
 
 template<typename T>

--- a/hdf/HDFAlnGroupGroup.hpp
+++ b/hdf/HDFAlnGroupGroup.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include "HDFArray.hpp"
 #include "HDFGroup.hpp"
-#include "saf/AlnGroup.hpp"
+#include <saf/AlnGroup.hpp> // pbdata
 
 class HDFAlnGroupGroup {
 public:

--- a/hdf/HDFAlnInfoGroup.hpp
+++ b/hdf/HDFAlnInfoGroup.hpp
@@ -8,8 +8,8 @@
 #include "HDFAtom.hpp"
 #include "HDFArray.hpp"
 #include "HDF2DArray.hpp"
-#include "saf/AlnInfo.hpp"
-#include "alignment/CmpAlignment.hpp"
+#include <saf/AlnInfo.hpp> // pbdata
+#include <alignment/CmpAlignment.hpp> // pbdata/alignment, not ../alignment!
 
 class HDFAlnInfoGroup {
 public:

--- a/hdf/HDFArray.hpp
+++ b/hdf/HDFArray.hpp
@@ -4,13 +4,13 @@
 #include <assert.h>
 #include <iostream>
 
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 
 #include "HDFConfig.hpp"
 #include "HDFData.hpp"
 #include "BufferedHDFArray.hpp"
-#include "DNASequence.hpp"
-#include "FASTQSequence.hpp"
+#include <DNASequence.hpp> // pbdata/
+#include <FASTQSequence.hpp> // pbdata/
 
 /*
  *

--- a/hdf/HDFAtom.hpp
+++ b/hdf/HDFAtom.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 
 #include "HDFConfig.hpp"
 #include "HDFGroup.hpp"

--- a/hdf/HDFBasReader.hpp
+++ b/hdf/HDFBasReader.hpp
@@ -7,12 +7,13 @@
 #include <string>
 #include <cstdint>
 
-#include "Enumerations.h"
-#include "FASTQSequence.hpp"
-#include "SMRTSequence.hpp"
-#include "VectorUtils.hpp"
-#include "ChangeListID.hpp"
-#include "reads/BaseFile.hpp"
+// pbdata/
+#include <Enumerations.h>
+#include <FASTQSequence.hpp>
+#include <SMRTSequence.hpp>
+#include <VectorUtils.hpp>
+#include <ChangeListID.hpp>
+#include <reads/BaseFile.hpp>
 
 #include "HDFArray.hpp"
 #include "HDF2DArray.hpp"

--- a/hdf/HDFBasWriter.hpp
+++ b/hdf/HDFBasWriter.hpp
@@ -2,10 +2,12 @@
 #define _BLASR_HDF_BAS_WRITER_HPP_
 
 #include <sstream>
-#include "Types.h"
-#include "Enumerations.h"
-#include "utils/SMRTReadUtils.hpp"
-#include "SMRTSequence.hpp"
+// pbdata/
+#include <Types.h>
+#include <Enumerations.h>
+#include <utils/SMRTReadUtils.hpp>
+#include <SMRTSequence.hpp>
+
 #include "HDFAtom.hpp"
 #include "HDFFile.hpp"
 #include "DatasetCollection.hpp"

--- a/hdf/HDFBaseCallsWriter.hpp
+++ b/hdf/HDFBaseCallsWriter.hpp
@@ -177,5 +177,5 @@ bool HDFBaseCallsWriter::HasPulseIndex(void) const
 {return (_HasQV(PacBio::BAM::BaseFeature::PULSE_CALL) and
          pulseIndexArray_.IsInitialized());}
 
-#endif
+#endif  // USE_PBBAM
 #endif

--- a/hdf/HDFBaxWriter.hpp
+++ b/hdf/HDFBaxWriter.hpp
@@ -5,8 +5,10 @@
 
 #include <sstream>
 #include <memory>
-#include "Enumerations.h"
-#include "SMRTSequence.hpp"
+// pbdata/
+#include <Enumerations.h>
+#include <SMRTSequence.hpp>
+
 #include "HDFFile.hpp"
 #include "HDFWriterBase.hpp"
 #include "HDFScanDataWriter.hpp"

--- a/hdf/HDFCmpExperimentGroup.hpp
+++ b/hdf/HDFCmpExperimentGroup.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <set>
 #include <cstdint>
-#include "Types.h"
+#include <Types.h> // pbdata/
 #include "HDFGroup.hpp"
 #include "HDFArray.hpp"
 #include "HDFCmpSupportedFields.hpp"

--- a/hdf/HDFCmpFile.hpp
+++ b/hdf/HDFCmpFile.hpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <map>
 
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 
 #include "HDFAtom.hpp"
 #include "HDFArray.hpp"
@@ -24,16 +24,18 @@
 #include "HDFCmpSupportedFields.hpp"
 #include "HDFFileLogGroup.hpp"
 
-#include "SMRTSequence.hpp"
+// pbdata/
+#include <SMRTSequence.hpp>
+#include <alignment/CmpAlignment.hpp> // not ../alignment!
+#include <saf/RefInfo.hpp>
 
-#include "datastructures/alignment/CmpFile.hpp"
-#include "datastructures/alignment/Alignment.hpp"
-#include "datastructures/alignment/AlignmentCandidate.hpp"
-#include "alignment/CmpAlignment.hpp"
-#include "datastructures/alignment/CmpReadGroupTable.h"
-#include "datastructures/alignment/CmpRefSeqTable.h"
-#include "datastructures/alignment/ByteAlignment.h"
-#include "saf/RefInfo.hpp"
+// alignment/datastructures/alignment  -- Yes, seriously.
+#include <datastructures/alignment/CmpFile.hpp>
+#include <datastructures/alignment/Alignment.hpp>
+#include <datastructures/alignment/AlignmentCandidate.hpp>
+#include <datastructures/alignment/CmpReadGroupTable.h>
+#include <datastructures/alignment/CmpRefSeqTable.h>
+#include <datastructures/alignment/ByteAlignment.h>
 
 using namespace H5;
 using namespace std;

--- a/hdf/HDFCmpReader.hpp
+++ b/hdf/HDFCmpReader.hpp
@@ -2,16 +2,18 @@
 #define _BLASR_HDF_CMP_READER_HPP_
 #error "Does this compile anymore? Where is data/hdf/*.h?"
 
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 #include <iostream>
 #include <assert.h>
-#include "datastructures/alignment/CmpFile.h"
-#include "datastructures/alignment/Alignment.h"
-#include "datastructures/alignment/AlignmentCandidate.h"
-#include "datastructures/alignment/CmpAlignment.h"
-#include "datastructures/alignment/CmpReadGroupTable.h"
-#include "datastructures/alignment/CmpRefSeqTable.h"
-#include "datastructures/alignment/ByteAlignment.h"
+// ../alignment/datastructures/alignment
+#include <datastructures/alignment/CmpFile.h>
+#include <datastructures/alignment/Alignment.h>
+#include <datastructures/alignment/AlignmentCandidate.h>
+#include <datastructures/alignment/CmpAlignment.h>
+#include <datastructures/alignment/CmpReadGroupTable.h>
+#include <datastructures/alignment/CmpRefSeqTable.h>
+#include <datastructures/alignment/ByteAlignment.h>
+
 #include "data/hdf/HDFAtom.h"
 #include "data/hdf/HDFArray.h"
 #include "data/hdf/HDF2DArray.h"
@@ -25,7 +27,7 @@
 #include "HDFMovieInfoGroup.h"
 #include "HDFCmpRootGroup.h"
 #include "HDFCmpSupportedFields.h"
-#include "SMRTSequence.h"
+#include "SMRTSequence.h" // ../pbdata/SMRTSequence.h or ../../blasr/SMRTSequence.h ???
 #include <sstream>
 #include <map>
 

--- a/hdf/HDFCmpRootGroup.hpp
+++ b/hdf/HDFCmpRootGroup.hpp
@@ -3,7 +3,7 @@
 
 #include "HDFAtom.hpp"
 #include "HDF2DArray.hpp"
-#include "datastructures/alignment/CmpFile.hpp"
+#include <datastructures/alignment/CmpFile.hpp> // ../alignment/datastructures/alignment
 template <typename T_Alignment>
 class HDFCmpRootGroup {
  public:

--- a/hdf/HDFData.hpp
+++ b/hdf/HDFData.hpp
@@ -2,7 +2,7 @@
 #define _BLASR_HDF_DATA_HPP_
 
 #include <string>
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 #include "HDFConfig.hpp"
 #include "HDFGroup.hpp"
 #include "HDFAttributable.hpp"

--- a/hdf/HDFFile.hpp
+++ b/hdf/HDFFile.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 #include "HDFConfig.hpp"
 #include "HDFGroup.hpp"
 

--- a/hdf/HDFMovieInfoGroup.hpp
+++ b/hdf/HDFMovieInfoGroup.hpp
@@ -3,7 +3,7 @@
 
 #include "HDFGroup.hpp"
 #include "HDFArray.hpp"
-#include "saf/MovieInfo.hpp"
+#include <saf/MovieInfo.hpp> // pbdata/
 
 class HDFMovieInfoGroup {
  public:

--- a/hdf/HDFPlsReader.hpp
+++ b/hdf/HDFPlsReader.hpp
@@ -9,10 +9,13 @@
 #include "HDFPulseDataFile.hpp"
 #include "DatasetCollection.hpp"
 #include "HDFZMWReader.hpp"
-#include "reads/PulseFile.hpp"
 #include "HDFScanDataReader.hpp"
-#include "FASTQSequence.hpp"
-#include "VectorUtils.hpp"
+
+// pbdata/
+#include <reads/PulseFile.hpp>
+#include <FASTQSequence.hpp>
+#include <VectorUtils.hpp>
+
 #include <sstream>
 #include <vector>
 #include <set>

--- a/hdf/HDFPlsWriter.hpp
+++ b/hdf/HDFPlsWriter.hpp
@@ -9,8 +9,10 @@
 #include "data/hdf/HDFAtom.h"
 #include "data/hdf/HDFFile.h"
 #include "data/hdf/PlatformId.h"
-#include "utils/SMRTReadUtils.h"
-#include "FASTQSequence.h"
+// pbdata/
+#include <utils/SMRTReadUtils.h>
+#include <FASTQSequence.h>
+
 #include <sstream>
 
 using namespace H5;

--- a/hdf/HDFPulseDataFile.hpp
+++ b/hdf/HDFPulseDataFile.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 #include "HDFGroup.hpp"
 #include "HDFZMWReader.hpp"
 #include "HDFScanDataReader.hpp"

--- a/hdf/HDFPulseWriter.hpp
+++ b/hdf/HDFPulseWriter.hpp
@@ -5,8 +5,10 @@
 
 #include <sstream>
 #include <memory>
-#include "Enumerations.h"
-#include "SMRTSequence.hpp"
+// pbdata/
+#include <Enumerations.h>
+#include <SMRTSequence.hpp>
+
 #include "HDFFile.hpp"
 #include "HDFWriterBase.hpp"
 #include "HDFScanDataWriter.hpp"
@@ -109,5 +111,5 @@ private:
 inline bool HDFPulseWriter::HasRegions(void) const
 { return bool(regionsWriter_); }
 
-#endif
+#endif  // USE_PBBAM
 #endif

--- a/hdf/HDFRefGroupGroup.hpp
+++ b/hdf/HDFRefGroupGroup.hpp
@@ -4,7 +4,7 @@
 #include "HDFAtom.hpp"
 #include "HDFArray.hpp"
 #include "HDFGroup.hpp"
-#include "saf/RefGroup.hpp"
+#include <saf/RefGroup.hpp> // pbdata/
 
 class HDFRefGroupGroup {
  public:

--- a/hdf/HDFRefInfoGroup.hpp
+++ b/hdf/HDFRefInfoGroup.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_HDF_REF_INFO_HPP_
 #define _BLASR_HDF_REF_INFO_HPP_
 
-#include "saf/RefInfo.hpp"
+#include <saf/RefInfo.hpp> // pbdata/
 
 class HDFRefInfoGroup {
  public:

--- a/hdf/HDFRegionTableReader.hpp
+++ b/hdf/HDFRegionTableReader.hpp
@@ -4,9 +4,9 @@
 #include <string>
 #include <vector>
 
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 
-#include "reads/RegionTable.hpp"
+#include <reads/RegionTable.hpp> // pbdata/
 #include "HDFFile.hpp"
 #include "HDFArray.hpp"
 #include "HDF2DArray.hpp"

--- a/hdf/HDFRegionTableWriter.hpp
+++ b/hdf/HDFRegionTableWriter.hpp
@@ -2,9 +2,9 @@
 #define _BLASR_HDF_REGION_TABLE_WRITER_HPP_
 
 #include <string>
-
-#include "Enumerations.h"
-#include "reads/RegionTable.hpp"
+// pbdata/
+#include <Enumerations.h>
+#include <reads/RegionTable.hpp>
 #include "HDFFile.hpp"
 #include "HDFArray.hpp"
 #include "HDF2DArray.hpp"

--- a/hdf/HDFRegionsWriter.hpp
+++ b/hdf/HDFRegionsWriter.hpp
@@ -4,8 +4,10 @@
 #define _HDF_REGIONS_WRITER_HPP_
 
 #include <string>
-#include "Enumerations.h"
-#include "reads/RegionTable.hpp"
+// pbdata/
+#include <Enumerations.h>
+#include <reads/RegionTable.hpp>
+
 #include "HDFFile.hpp"
 #include "HDFArray.hpp"
 #include "HDF2DArray.hpp"

--- a/hdf/HDFScanDataReader.hpp
+++ b/hdf/HDFScanDataReader.hpp
@@ -3,8 +3,9 @@
 
 #include <map>
 #include <string>
-#include "Enumerations.h"
-#include "reads/ScanData.hpp"
+// pbdata/
+#include <Enumerations.h>
+#include <reads/ScanData.hpp>
 #include "HDFGroup.hpp"
 #include "HDFFile.hpp"
 #include "HDFAtom.hpp"

--- a/hdf/HDFScanDataWriter.hpp
+++ b/hdf/HDFScanDataWriter.hpp
@@ -8,9 +8,10 @@
 #include "HDFFile.hpp"
 #include "HDFGroup.hpp"
 #include "HDFAtom.hpp"
-#include "Enumerations.h"
-#include "reads/ScanData.hpp"
-#include "reads/AcqParams.hpp"
+// pbdata/
+#include <Enumerations.h>
+#include <reads/ScanData.hpp>
+#include <reads/AcqParams.hpp>
 
 
 class HDFScanDataWriter {

--- a/hdf/HDFUtils.hpp
+++ b/hdf/HDFUtils.hpp
@@ -8,7 +8,7 @@
 #include "HDFScanDataReader.hpp"
 #include "HDFBasReader.hpp"
 #include "HDFRegionTableReader.hpp"
-#include "reads/RegionTable.hpp"
+#include <reads/RegionTable.hpp> // pbdata/
 
 
 // Given a PacBio (pls/plx/bas/bax/ccs/rgn).h5 file, which contains its movie 

--- a/hdf/HDFWriteBuffer.hpp
+++ b/hdf/HDFWriteBuffer.hpp
@@ -2,7 +2,7 @@
 #define _BLASR_HDF_WRITE_BUFFER_HPP_
 
 #include <cstddef>
-#include "utils.hpp"
+#include <utils.hpp> // pbdata/
 
 template<typename T>
 class HDFWriteBuffer {

--- a/hdf/HDFZMWMetricsWriter.hpp
+++ b/hdf/HDFZMWMetricsWriter.hpp
@@ -4,7 +4,7 @@
 #ifndef _BLASR_HDF_HDFZMWMETRICSWriter_HPP_
 #define _BLASR_HDF_HDFZMWMETRICSWriter_HPP_
 
-#include "SMRTSequence.hpp"
+#include <SMRTSequence.hpp> // pbdata
 #include "HDFWriterBase.hpp"
 #include "BufferedHDFArray.hpp"
 #include "BufferedHDF2DArray.hpp"

--- a/hdf/HDFZMWReader.hpp
+++ b/hdf/HDFZMWReader.hpp
@@ -2,8 +2,8 @@
 #define _BLASR_HDF_ZMW_READER_HPP_
 
 #include <cstdint>
-#include "H5Cpp.h"
-#include "reads/ZMWGroupEntry.hpp"
+#include <H5Cpp.h>
+#include <reads/ZMWGroupEntry.hpp> // pbdata
 #include "HDFArray.hpp"
 #include "HDF2DArray.hpp"
 #include "HDFGroup.hpp"

--- a/hdf/HDFZMWWriter.hpp
+++ b/hdf/HDFZMWWriter.hpp
@@ -7,7 +7,7 @@
 #include "HDFWriterBase.hpp"
 #include "BufferedHDFArray.hpp"
 #include "BufferedHDF2DArray.hpp"
-#include "SMRTSequence.hpp"
+#include <SMRTSequence.hpp> // pbdata
 #include <pbbam/BamRecord.h>
 
 class HDFBaseCallerWriter;

--- a/pbdata/DNASequence.hpp
+++ b/pbdata/DNASequence.hpp
@@ -12,7 +12,7 @@
 #include "libconfig.h"
 
 #ifdef USE_PBBAM
-#include "pbbam/BamRecord.h"
+#include <pbbam/BamRecord.h>
 #endif
 
 

--- a/pbdata/FASTAReader.cpp
+++ b/pbdata/FASTAReader.cpp
@@ -5,8 +5,8 @@
 #include <limits.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include "sys/mman.h"
-#include "sys/fcntl.h"
+#include <sys/mman.h>
+#include <sys/fcntl.h>
 
 #include "Enumerations.h"
 #include "NucConversion.hpp"

--- a/pbdata/alignment/CmpAlignment.hpp
+++ b/pbdata/alignment/CmpAlignment.hpp
@@ -7,8 +7,8 @@
 #include <assert.h>
 #include <algorithm>
 
-#include "Types.h"
-#include "Enumerations.h"
+#include "../Types.h"
+#include "../Enumerations.h"
 
 class CmpAlignmentBase  {
 public:

--- a/pbdata/amos/AfgBasWriter.hpp
+++ b/pbdata/amos/AfgBasWriter.hpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <fstream>
 #include <sstream>
-#include "SMRTSequence.hpp"
+#include "../SMRTSequence.hpp"
 
 class AfgBasWriter {
     // TODO correct file type? outFile

--- a/pbdata/loadpulses/MetricField.hpp
+++ b/pbdata/loadpulses/MetricField.hpp
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 
-#include "Types.h"
+#include "../Types.h"
 
 enum FieldType {BasField, PlsField};
 

--- a/pbdata/loadpulses/MovieAlnIndexLookupTable.hpp
+++ b/pbdata/loadpulses/MovieAlnIndexLookupTable.hpp
@@ -39,7 +39,7 @@
 #include <iostream>
 #include <string>
 
-#include "Types.h"
+#include "../Types.h"
 
 class MovieAlnIndexLookupTable {
 public: 

--- a/pbdata/makefile
+++ b/pbdata/makefile
@@ -7,8 +7,8 @@ include ${THISDIR}/../rules.mk
 CXXOPTS  += -std=c++11 -pedantic -Wall -Wextra
 # CURDIR should have libconfig.h
 INCLUDES += ${CURDIR}
-INCLUDES += ${THISDIR} matrix reads qvs metagenome saf utils
-INCLUDES += ${LIBBLASR_INC}
+#INCLUDES += ${THISDIR} matrix reads qvs metagenome saf utils
+#INCLUDES += ${LIBBLASR_INC}  # ../alignment is no longer a circular dependency, apparently.
 SYSINCLUDES = ${PBBAM_INC} ${HTSLIB_INC} ${BOOST_INC}
 LIBS     += ${PBBAM_LIB} ${HTSLIB_LIB}
 LDFLAGS  += $(patsubst %,-L%,${LIBS})

--- a/pbdata/matrix/FlatMatrixImpl.hpp
+++ b/pbdata/matrix/FlatMatrixImpl.hpp
@@ -2,8 +2,8 @@
 #include <vector>
 #include <iostream>
 #include <assert.h>
-#include "Types.h"
-#include "utils.hpp"
+#include "../Types.h"
+#include "../utils.hpp"
 #include "FlatMatrix.hpp"
 
 template<typename T>

--- a/pbdata/matrix/Matrix.hpp
+++ b/pbdata/matrix/Matrix.hpp
@@ -2,7 +2,7 @@
 #define _BLASR_MATRIX_HPP_
 
 #include <vector>
-#include "Types.h"
+#include "../Types.h"
 
 template<typename T>
 void CreateMatrix(int rows, int cols, std::vector<T*> matrix); 

--- a/pbdata/matrix/MatrixImpl.hpp
+++ b/pbdata/matrix/MatrixImpl.hpp
@@ -5,8 +5,8 @@
 #include <iostream>
 #include <fstream>
 #include <stdint.h>
-#include "utils.hpp"
-#include "Types.h"
+#include "../utils.hpp"
+#include "../Types.h"
 
 template<typename T>
 void CreateMatrix(int rows, int cols, std::vector<T*> matrix) {

--- a/pbdata/metagenome/FindRandomSequence.hpp
+++ b/pbdata/metagenome/FindRandomSequence.hpp
@@ -2,8 +2,8 @@
 #define _FIND_RANDOM_SEQUENCE_HPP_
 
 #include <vector>
-#include "DNASequence.hpp"
-#include "statistics/StatUtils.hpp"
+#include "../DNASequence.hpp"
+#include "statistics/StatUtils.hpp" // Where does this come from? Does this compile anymore?
 
 
 template<typename T_Sequence>

--- a/pbdata/metagenome/SequenceIndexDatabase.hpp
+++ b/pbdata/metagenome/SequenceIndexDatabase.hpp
@@ -9,9 +9,9 @@
 #include <sstream>
 #include <cstring>
 #include <algorithm>
-#include "Types.h"
-#include "DNASequence.hpp"
-#include "StringUtils.hpp"
+#include "../Types.h"
+#include "../DNASequence.hpp"
+#include "../StringUtils.hpp"
 
 
 #define SEQUENCE_INDEX_DATABASE_MAGIC 1233211233
@@ -91,6 +91,6 @@ public:
     DNALength Length(DNALength pos);
 };
 
-#include "metagenome/SequenceIndexDatabaseImpl.hpp"
+#include "SequenceIndexDatabaseImpl.hpp"
 
 #endif

--- a/pbdata/metagenome/TitleTable.hpp
+++ b/pbdata/metagenome/TitleTable.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <string.h>
 #include <vector>
-#include "utils.hpp"
+#include "../utils.hpp"
 
 class TitleTable {
 public: 

--- a/pbdata/qvs/QualityValue.cpp
+++ b/pbdata/qvs/QualityValue.cpp
@@ -1,5 +1,5 @@
 #include <math.h>
-#include "defs.h"
+#include "../defs.h"
 #include <assert.h>
 #include "QualityValue.hpp"
 

--- a/pbdata/qvs/QualityValue.hpp
+++ b/pbdata/qvs/QualityValue.hpp
@@ -2,7 +2,7 @@
 #define _BLASR_QUALITY_VALUE_HPP_
 
 #include <stdint.h>
-#include "ChangeListID.hpp"
+#include "../ChangeListID.hpp"
 
 typedef unsigned char QualityValue;
 typedef float QualityProbability;

--- a/pbdata/qvs/QualityValueVector.hpp
+++ b/pbdata/qvs/QualityValueVector.hpp
@@ -4,8 +4,8 @@
 #include <cstddef>
 #include <ostream>
 #include <cstring>
-#include "Types.h"
-#include "utils.hpp"
+#include "../Types.h"
+#include "../utils.hpp"
 #include "QualityValue.hpp"
 
 template<typename T_QV>

--- a/pbdata/qvs/QualityValueVectorImpl.hpp
+++ b/pbdata/qvs/QualityValueVectorImpl.hpp
@@ -1,6 +1,6 @@
 #ifndef _BLASR_QUALITY_VALUE_VECTOR_IMPL_HPP_
 #define _BLASR_QUALITY_VALUE_VECTOR_IMPL_HPP_
-#include "NucConversion.hpp"
+#include "../NucConversion.hpp"
 
 template<typename T_QV>
 T_QV& QualityValueVector<T_QV>::operator[](unsigned int pos) const {

--- a/pbdata/reads/AcqParams.hpp
+++ b/pbdata/reads/AcqParams.hpp
@@ -1,7 +1,7 @@
 #ifndef DATASTRUCTURES_READS_ACQ_PARAMS_H_
 #define DATASTRUCTURES_READS_ACQ_PARAMS_H_
 
-#include "Types.h"
+#include "../Types.h"
 class ScanData;
 class HDFScanDataWriter;
 

--- a/pbdata/reads/BaseFile.hpp
+++ b/pbdata/reads/BaseFile.hpp
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 #include <vector>
-#include "Enumerations.h"
-#include "SMRTSequence.hpp"
+#include "../Enumerations.h"
+#include "../SMRTSequence.hpp"
 
 #include "HoleXY.hpp"
 #include "PulseBaseCommon.hpp"

--- a/pbdata/reads/PulseFile.hpp
+++ b/pbdata/reads/PulseFile.hpp
@@ -3,10 +3,10 @@
 
 #include <map>
 #include <vector>
-#include "Types.h"
-#include "Enumerations.h"
-#include "DNASequence.hpp"
-#include "SMRTSequence.hpp"
+#include "../Types.h"
+#include "../Enumerations.h"
+#include "../DNASequence.hpp"
+#include "../SMRTSequence.hpp"
 #include "PulseBaseCommon.hpp"
 #include "ScanData.hpp"
 

--- a/pbdata/reads/PulseFileImpl.hpp
+++ b/pbdata/reads/PulseFileImpl.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_PULSE_FILE_IMPL_HPP_
 #define _BLASR_PULSE_FILE_IMPL_HPP_
 
-#include "utils.hpp"
+#include "../utils.hpp"
 
 template<typename T_FieldType>
 void PulseFile::StoreField(std::vector<T_FieldType> &source, int *basToPlsIndex, T_FieldType *dest, const DSLength destLength) {

--- a/pbdata/reads/RegionAnnotation.hpp
+++ b/pbdata/reads/RegionAnnotation.hpp
@@ -10,9 +10,9 @@
 #include <vector>
 #include <map>
 #include <ostream>
-#include "Types.h"
-#include "Enumerations.h"
-#include "PacBioDefs.h"
+#include "../Types.h"
+#include "../Enumerations.h"
+#include "../PacBioDefs.h"
 #include "RegionTypeMap.hpp"
 
 

--- a/pbdata/reads/RegionTable.hpp
+++ b/pbdata/reads/RegionTable.hpp
@@ -10,9 +10,9 @@
 #include <vector>
 #include <map>
 #include <ostream>
-#include "Types.h"
-#include "Enumerations.h"
-#include "PacBioDefs.h"
+#include "../Types.h"
+#include "../Enumerations.h"
+#include "../PacBioDefs.h"
 #include "RegionAnnotation.hpp"
 #include "RegionAnnotations.hpp"
 

--- a/pbdata/reads/RegionTypeMap.hpp
+++ b/pbdata/reads/RegionTypeMap.hpp
@@ -9,8 +9,8 @@
 #include <vector>
 #include <map>
 #include <algorithm>
-#include "Types.h"
-#include "Enumerations.h"
+#include "../Types.h"
+#include "../Enumerations.h"
 
 
 class RegionTypeMap {

--- a/pbdata/reads/ScanData.hpp
+++ b/pbdata/reads/ScanData.hpp
@@ -5,9 +5,9 @@
 
 #include <string>
 #include <map>
-#include "reads/AcqParams.hpp"
-#include "Enumerations.h"
-#include "PacBioDefs.h"
+#include "AcqParams.hpp"
+#include "../Enumerations.h"
+#include "../PacBioDefs.h"
 
 class HDFScanDataReader;
 class HDFScanDataWriter;

--- a/pbdata/reads/ZMWGroupEntry.cpp
+++ b/pbdata/reads/ZMWGroupEntry.cpp
@@ -1,5 +1,5 @@
 #include <stdint.h>
-#include "Types.h"
+#include "../Types.h"
 #include "ZMWGroupEntry.hpp"
 ZMWGroupEntry::ZMWGroupEntry() {
     holeNumber = x = y = 0;

--- a/pbdata/reads/ZMWGroupEntry.hpp
+++ b/pbdata/reads/ZMWGroupEntry.hpp
@@ -1,7 +1,7 @@
 #ifndef _BLASR_ZMW_GROUP_ENTRY_HPP_
 #define _BLASR_ZMW_GROUP_ENTRY_HPP_
 
-#include "Types.h"
+#include "../Types.h"
 
 class ZMWGroupEntry {
  public:

--- a/pbdata/saf/AlnInfo.hpp
+++ b/pbdata/saf/AlnInfo.hpp
@@ -3,8 +3,8 @@
 
 #include <cstdint>
 #include <vector>
-#include "Types.h"
-#include "alignment/CmpAlignment.hpp"
+#include "../Types.h"
+#include "../alignment/CmpAlignment.hpp"
 
 class AlnInfo {
 public:

--- a/pbdata/saf/MovieInfo.hpp
+++ b/pbdata/saf/MovieInfo.hpp
@@ -1,7 +1,7 @@
 #ifndef DATASTRUCTURES_SAF_HDF_MOVIE_INFO_H_
 #define DATASTRUCTURES_SAF_HDF_MOVIE_INFO_H_
 
-#include "Types.h"
+#include "../Types.h"
 #include <string>
 #include <vector>
 

--- a/pbdata/sam/AlignmentSet.hpp
+++ b/pbdata/sam/AlignmentSet.hpp
@@ -5,11 +5,11 @@
 #include <string>
 #include <vector>
 
-#include "FASTASequence.hpp"
-#include "sam/ReadGroup.hpp"
-#include "sam/ReferenceSequence.hpp"
-#include "sam/SAMAlignment.hpp"
-#include "sam/SAMHeader.hpp"
+#include "../FASTASequence.hpp"
+#include "ReadGroup.hpp"
+#include "ReferenceSequence.hpp"
+#include "SAMAlignment.hpp"
+#include "SAMHeader.hpp"
 
 template<typename T_ReferenceSequence=SAMReferenceSequence, typename T_ReadGroup=SAMReadGroup, typename T_Alignment=SAMAlignment>
 class AlignmentSet {

--- a/pbdata/sam/ReferenceSequence.hpp
+++ b/pbdata/sam/ReferenceSequence.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "sam/SAMKeywordValuePair.hpp"
+#include "SAMKeywordValuePair.hpp"
 
 class SAMReferenceSequence {
  public:

--- a/pbdata/sam/SAMAlignment.hpp
+++ b/pbdata/sam/SAMAlignment.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <sstream>
 
-#include "sam/SAMKeywordValuePair.hpp"
-#include "sam/CigarString.h"
+#include "SAMKeywordValuePair.hpp"
+#include "CigarString.h"
 
 class SAMAlignment {
  public:

--- a/pbdata/sam/SAMHeader.hpp
+++ b/pbdata/sam/SAMHeader.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "sam/SAMKeywordValuePair.hpp"
+#include "SAMKeywordValuePair.hpp"
 
 class SAMHeader {
  public:

--- a/pbdata/sam/SAMKeywordValuePair.hpp
+++ b/pbdata/sam/SAMKeywordValuePair.hpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <vector>
 
-#include "StringUtils.hpp"
+#include "../StringUtils.hpp"
 
 
 class SAMKeywordValuePair {

--- a/pbdata/sam/SAMReader.hpp
+++ b/pbdata/sam/SAMReader.hpp
@@ -1,13 +1,13 @@
 #ifndef _BLASR_SAM_READER_HPP_
 #define _BLASR_SAM_READER_HPP_
 
-#include "sam/SAMKeywordValuePair.hpp"
-#include "sam/ReadGroup.hpp"
-#include "sam/ReferenceSequence.hpp"
+#include "SAMKeywordValuePair.hpp"
+#include "ReadGroup.hpp"
+#include "ReferenceSequence.hpp"
 
-#include "sam/AlignmentSet.hpp"
-#include "StringUtils.hpp"
-#include "utils.hpp"
+#include "AlignmentSet.hpp"
+#include "../StringUtils.hpp"
+#include "../utils.hpp"
 
 template<typename T_ReferenceSequence, typename T_ReadGroup, typename T_SAMAlignment>
 class SAMReader {

--- a/pbdata/utils/BitUtils.hpp
+++ b/pbdata/utils/BitUtils.hpp
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 #include <bitset>
-#include "Types.h"
+#include "../Types.h"
 
 int32_t CountBits(uint32_t v); 
 

--- a/pbdata/utils/SMRTReadUtils.hpp
+++ b/pbdata/utils/SMRTReadUtils.hpp
@@ -3,8 +3,8 @@
 
 #include <stdlib.h>
 
-#include "FASTQSequence.hpp"
-#include "StringUtils.hpp"
+#include "../FASTQSequence.hpp"
+#include "../StringUtils.hpp"
 
 void GetSMRTReadCoordinates(FASTQSequence &seq, int &x, int &y);
 

--- a/pbdata/utils/SMRTTitle.cpp
+++ b/pbdata/utils/SMRTTitle.cpp
@@ -1,4 +1,4 @@
-#include "utils/SMRTTitle.hpp"
+#include "SMRTTitle.hpp"
 
 /// Parse a Pacbio read name, it is a SMRTTitle, get movieName, 
 /// holeNumber, start and end, set isSMRTTitle to be true. 

--- a/pbdata/utils/SMRTTitle.hpp
+++ b/pbdata/utils/SMRTTitle.hpp
@@ -3,8 +3,8 @@
 #include <string>
 #include <vector>
 #include <sstream>
-#include "Types.h"
-#include "StringUtils.hpp"
+#include "../Types.h"
+#include "../StringUtils.hpp"
 
 class SMRTTitle {
 public:

--- a/pbdata/utils/TimeUtils.cpp
+++ b/pbdata/utils/TimeUtils.cpp
@@ -1,7 +1,7 @@
 #include <sstream> 
 #include <time.h>
 #include <iomanip> // std::setfill setd::setw
-#include "utils/TimeUtils.hpp"
+#include "TimeUtils.hpp"
 
 std::string GetTimestamp() {
   time_t timer;


### PR DESCRIPTION
Drop THISDIR and its subdirs from inc-path.

Though if we build in-tree, then we still have CURDIR for libconfig.h, for
now.

Note that libconfig.h is in pbdata, external to others.