### PR TITLE
Fix bam2plx jenkins test:

### DIFF
--- a/hdf/HDFPulseWriter.cpp
+++ b/hdf/HDFPulseWriter.cpp
@@ -130,6 +130,7 @@ bool HDFPulseWriter::WriteOneZmw(const SMRTSequence & seq,
 } 
 
 bool HDFPulseWriter::WriteFakeDataSets() {
-    return pulsecallsWriter_->WriteFakeDataSets();
+    return basecallsWriter_->WriteFakeDataSets() and
+           pulsecallsWriter_->WriteFakeDataSets();
 }
 #endif // ifndef USE_PBBAM


### PR DESCRIPTION
Add fake dataset QualityValue back plx.h5
/PulseData/BaseCalls.