### PR TITLE
Build relative paths

### DIFF
--- a/alignment/makefile
+++ b/alignment/makefile
@@ -22,7 +22,7 @@ paths := . simulator format files utils tuples statistics qvs suffixarray \
 	datastructures/alignment datastructures/alignmentset datastructures/anchoring datastructures/tuplelists \
 	algorithms/alignment algorithms/alignment/sdp algorithms/anchoring algorithms/compare algorithms/sorting \
 	query
-paths := $(patsubst %,${THISDIR}%,${paths})
+#paths := $(patsubst %,${THISDIR}%,${paths})
 sources := $(shell find ${THISDIR} -name '*.cpp')
 
 ifdef nohdf

--- a/hdf/makefile
+++ b/hdf/makefile
@@ -16,7 +16,7 @@ foo:
 	echo ${SYSINCLUDES}
 all: libpbihdf.a libpbihdf${SH_LIB_EXT}
 
-paths := ${THISDIR}
+paths := .
 sources := $(wildcard ${THISDIR}*.cpp)
 sources := $(notdir ${sources})
 objects := $(sources:.cpp=.o)

--- a/pbdata/makefile
+++ b/pbdata/makefile
@@ -6,7 +6,7 @@ include ${THISDIR}/../rules.mk
 
 CXXOPTS  += -std=c++11 -pedantic -Wall -Wextra
 # CURDIR should have libconfig.h
-INCLUDES += ${CURDIR}
+#INCLUDES += ${CURDIR}
 SYSINCLUDES = ${PBBAM_INC} ${HTSLIB_INC} ${BOOST_INC}
 LIBS     += ${PBBAM_LIB} ${HTSLIB_LIB}
 LDFLAGS  += $(patsubst %,-L%,${LIBS})
@@ -14,7 +14,7 @@ LDFLAGS  += $(patsubst %,-L%,${LIBS})
 all: libpbdata.a libpbdata${SH_LIB_EXT}
 
 paths := . matrix reads metagenome qvs saf utils loadpulses alignment amos sam
-paths := $(patsubst %,${THISDIR}%,${paths})
+#paths := $(patsubst %,${THISDIR}%,${paths})
 sources := $(shell find ${THISDIR} -name '*.cpp')
 sources := $(notdir ${sources})
 objects := $(sources:.cpp=.o)


### PR DESCRIPTION
This simple change makes the compile lines much easier to read (and more easily cached, if that matters). These 3 libs *are* in the same, repo, so they may as well use relative paths. Anyway, I think the present change is really a no-op, since it applies to files in CURDIR.