### PR TITLE
FIx clang warnings

### DIFF
--- a/alignment/MappingMetrics.cpp
+++ b/alignment/MappingMetrics.cpp
@@ -13,9 +13,9 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 
     uint64_t start, end, delta, nano;
 
-    task_basic_info_data_t tinfo;
-    task_thread_times_info_data_t ttinfo;
-    mach_msg_type_number_t tflag;
+    //task_basic_info_data_t tinfo;
+    //task_thread_times_info_data_t ttinfo;
+    //mach_msg_type_number_t tflag;
 
     int retval = -1;
     switch (clk_id) {

--- a/alignment/algorithms/alignment/AlignmentUtilsImpl.hpp
+++ b/alignment/algorithms/alignment/AlignmentUtilsImpl.hpp
@@ -66,7 +66,7 @@ int ComputeAlignmentScore(std::string &queryStr, std::string &textStr, T_ScoreFn
     }
     VectorIndex i;
     int score = 0;
-    int alignStrLen = queryStr.size();
+    VectorIndex alignStrLen = queryStr.size();
     for(i = 0; i < alignStrLen; i++) {
         if (queryStr[i] != '-' and
             textStr[i] != '-') {
@@ -77,7 +77,7 @@ int ComputeAlignmentScore(std::string &queryStr, std::string &textStr, T_ScoreFn
                 //
                 // Compute affine gap scoring.  For now this uses symmetric insertion/deletion penalties. 
                 //
-                int gapEnd = i;
+                unsigned gapEnd = i;
                 while (gapEnd < queryStr.size() and gapEnd < textStr.size() and 
                         (queryStr[gapEnd] == '-' or textStr[gapEnd] == '-')) {
                     ++gapEnd;
@@ -523,7 +523,7 @@ void QVsToCmpH5QVs(const std::string &qvs,
     char tagGapChar = 'N';
     UChar qvGapChar = 255; 
 
-    for (int i=0; i<byteAlignment.size(); i++) {
+    for (unsigned i=0; i<byteAlignment.size(); i++) {
         if (byteAlignment[i] >> 4 == 0) { //Look at upper bits to get query char
             if (isTag) {
                 gappedQVs->push_back(tagGapChar);

--- a/alignment/algorithms/alignment/ExtendAlign.hpp
+++ b/alignment/algorithms/alignment/ExtendAlign.hpp
@@ -102,7 +102,8 @@ template<typename T_Alignment,
             // terminating the alignment
             // 
             ) {
-        (void)(queryPos); (void)(refPos);
+        PB_UNUSED(queryPos);
+        PB_UNUSED(refPos);
         //
         // Try extending an alignment in the forward direction as long the
         // maximum score that is extended is above a threshold above the
@@ -111,7 +112,7 @@ template<typename T_Alignment,
         // matrices since reusable buffers are used).   
         // 
 
-        int nCols = 2 * k + 1 + 1;  // 2*k is for search space, +1 is for the
+        DNALength nCols = 2 * k + 1 + 1;  // 2*k is for search space, +1 is for the
         // middle band, and the last +1 is for the
         // boundary conditions at the beginning of
         // the array.
@@ -144,7 +145,8 @@ template<typename T_Alignment,
         // Initialize boundary conditions.
         //
 
-        int q, t;
+        DNALength q;
+        int t;
         // Initialize first column for insertions.
         int firstIndex;
         fill(scoreMat.begin(), scoreMat.begin() + matSize, 0);

--- a/alignment/algorithms/alignment/IDSScoreFunction.hpp
+++ b/alignment/algorithms/alignment/IDSScoreFunction.hpp
@@ -39,24 +39,40 @@ class IDSScoreFunction : public BaseScoreFunction {
 
 
         int Deletion(T_QuerySequence &seq, DNALength pos) {
+            PB_UNUSED(seq);
+            PB_UNUSED(pos);
             std::cout << "IDS. For now, deletion must be specialized with FASTQ or FASTA Sequences. " << std::endl;
             exit(1);
             return 0;
         }
         int Deletion(T_RefSequence &refSeq, DNALength refPos, T_QuerySequence &querySeq, DNALength queryPos) {
+            PB_UNUSED(refSeq);
+            PB_UNUSED(refPos);
+            PB_UNUSED(querySeq);
+            PB_UNUSED(queryPos);
             std::cout << "IDS. For now, this function must be specialized with either FASTQ or FASTA sequences"<<std::endl;
             exit(1);
         }
         int Match(T_RefSequence &ref, DNALength refPos, T_QuerySequence &query, DNALength queryPos) {
+            PB_UNUSED(ref);
+            PB_UNUSED(refPos);
+            PB_UNUSED(query);
+            PB_UNUSED(queryPos);
             std::cout << "IDS. For now, this function must be specialized with either FASTQ or FASTA sequences" << std::endl;
             return 0;
             exit(1);
         }
         int Insertion(T_RefSequence &refSeq, DNALength refPos, T_QuerySequence &querySeq, DNALength queryPos) {
+            PB_UNUSED(refSeq);
+            PB_UNUSED(refPos);
+            PB_UNUSED(querySeq);
+            PB_UNUSED(queryPos);
             std::cout << "IDS. For now, this function must be specialized with either FASTQ or FASTA sequences"<<std::endl;
             exit(1);
         }	
         int Insertion(T_QuerySequence &seq, DNALength pos) {
+            PB_UNUSED(seq);
+            PB_UNUSED(pos);
             std::cout << "IDS. For now, this function must be specialized with either FASTQ or FASTA sequences" << std::endl;
             return 0;
             exit(1);

--- a/alignment/algorithms/alignment/KBandAlign.hpp
+++ b/alignment/algorithms/alignment/KBandAlign.hpp
@@ -51,7 +51,8 @@ void CreateThreeBitSequence(T_Sequence &origSeq, T_Sequence &threeBitSeq) {
 
 template<typename T_QuerySequence, typename T_TargetSequence, typename T_Alignment, typename T_ScoreFn>
 int KBandAlign(T_QuerySequence &qSeq, T_TargetSequence &tSeq,
-							 int matchMat[5][5], int ins, int del, int k,
+							 int matchMat[5][5], int ins, int del,
+               DNALength k,
 							 std::vector<int>   &scoreMat,
 							 std::vector<Arrow> &pathMat,
 							 T_Alignment   &alignment, 
@@ -89,7 +90,7 @@ int KBandAlign(T_QuerySequence &qSeq, T_TargetSequence &tSeq,
 	//
 	// Initialize the boundaries of the score and path matrices.
 	//
-	int q, t;
+	DNALength q, t;
 
 	for (q = 1; q <= k && q < qLen + 1; q++) {
 		scoreMat[rc2index(q, k - q, nCols)] = q * ins;
@@ -232,7 +233,7 @@ int KBandAlign(T_QuerySequence &qSeq, T_TargetSequence &tSeq,
 	int minLastColScore = globalMinScore, minLastRowScore = globalMinScore;
 
 	if (alignType == QueryFit or alignType == Fit) {
-		int q2,t2;
+		DNALength q2,t2;
 		q2 = qLen;
 		t2 = k - (qLen - tLen);
 		bool minScoreSet = false;
@@ -256,7 +257,7 @@ int KBandAlign(T_QuerySequence &qSeq, T_TargetSequence &tSeq,
 	}
 	if (alignType == TargetFit or alignType == Fit) {
 		//  Fit the target inside the query wh
-		int q2,t2;
+		DNALength q2,t2;
 		q2 = qLen;
 		t2 = k - (qLen - tLen);
 		bool minScoreSet = false;

--- a/alignment/algorithms/alignment/QualityValueScoreFunction.cpp
+++ b/alignment/algorithms/alignment/QualityValueScoreFunction.cpp
@@ -11,12 +11,18 @@ template<typename T_RefSequence, typename T_QuerySequence>
 int QualityValueScoreFunction<T_RefSequence, T_QuerySequence>::Deletion(
     T_RefSequence &seq, DNALength refPos, T_QuerySequence &querySeq, 
     DNALength queryPos) {
+    PB_UNUSED(seq);
+    PB_UNUSED(refPos);
+    PB_UNUSED(querySeq);
+    PB_UNUSED(queryPos);
     return QualityScoreTypeNotSpecified("Deletion");
 }
 		
 template<typename T_RefSequence, typename T_QuerySequence>
 int QualityValueScoreFunction<T_RefSequence, T_QuerySequence>::Deletion(
     T_RefSequence &seq, DNALength pos) {
+    PB_UNUSED(seq);
+    PB_UNUSED(pos);
     return QualityScoreTypeNotSpecified("Deletion");
 }
 
@@ -24,6 +30,10 @@ template<typename T_RefSequence, typename T_QuerySequence>
 int QualityValueScoreFunction<T_RefSequence, T_QuerySequence>::Match(
     T_RefSequence &ref, DNALength refPos, T_QuerySequence &query, 
     DNALength queryPos) {
+    PB_UNUSED(ref);
+    PB_UNUSED(refPos);
+    PB_UNUSED(query);
+    PB_UNUSED(queryPos);
     return QualityScoreTypeNotSpecified("Match");
 }
 
@@ -31,12 +41,18 @@ template<typename T_RefSequence, typename T_QuerySequence>
 int QualityValueScoreFunction<T_RefSequence, T_QuerySequence>::Insertion(
     T_RefSequence &ref, DNALength refPos, T_QuerySequence &seq, 
     DNALength pos) {
+    PB_UNUSED(ref);
+    PB_UNUSED(refPos);
+    PB_UNUSED(seq);
+    PB_UNUSED(pos);
     return QualityScoreTypeNotSpecified("Insertion");
 }
 
 template<typename T_RefSequence, typename T_QuerySequence>
 int QualityValueScoreFunction<T_RefSequence, T_QuerySequence>::Insertion(
     T_QuerySequence &seq, DNALength pos) {
+    PB_UNUSED(seq);
+    PB_UNUSED(pos);
     return QualityScoreTypeNotSpecified("Insertion");
 }
 
@@ -47,14 +63,16 @@ int QualityValueScoreFunction<T_RefSequence, T_QuerySequence>::Insertion(
 template<>
 int QualityValueScoreFunction<FASTASequence, FASTQSequence>::Deletion(
     FASTASequence &ref, DNALength pos) {
-    (void)(ref); (void)(pos);
+    PB_UNUSED(ref);
+    PB_UNUSED(pos);
     return del; // For now there is no global deletion quality value.
 }
 
 template<>
 int QualityValueScoreFunction<DNASequence, FASTQSequence>::Deletion(
     DNASequence &ref, DNALength pos) {
-    (void)(ref); (void)(pos);
+    PB_UNUSED(ref);
+    PB_UNUSED(pos);
     return del; // For now there is no global deletion quality value.
 }
 
@@ -62,7 +80,8 @@ template<>
 int QualityValueScoreFunction<DNASequence, FASTQSequence>::Deletion(
     DNASequence &seq, DNALength refPos, FASTQSequence &querySeq,
     DNALength queryPos) {
-    (void)(querySeq); (void)(queryPos);
+    PB_UNUSED(querySeq);
+    PB_UNUSED(queryPos);
     return Deletion(seq, refPos);
 }
 
@@ -77,7 +96,10 @@ template<>
 int QualityValueScoreFunction<DNASequence, FASTQSequence>::Insertion(
     DNASequence &ref, DNALength refPos, FASTQSequence &query, 
     DNALength pos) {
-    (void)(ref); (void)(refPos); (void)(query); (void)(pos);
+    PB_UNUSED(ref);
+    PB_UNUSED(refPos);
+    PB_UNUSED(query);
+    PB_UNUSED(pos);
     // Positive value for quality value penalizes the alignment.
     // return query.qual[pos];
     // return Insertion(query, pos);

--- a/alignment/algorithms/anchoring/FindMaxIntervalImpl.hpp
+++ b/alignment/algorithms/anchoring/FindMaxIntervalImpl.hpp
@@ -4,6 +4,8 @@
 template<typename T_Sequence, typename T_AnchorList>
 float DefaultWeightFunction<T_Sequence, T_AnchorList>::operator() (
     T_Sequence &text, T_Sequence &read, T_AnchorList matchPosList) {
+    PB_UNUSED(text);
+    PB_UNUSED(read);
     int i;
     float weight = 0;
     for (i = 0; i < matchPosList.size(); i++) {
@@ -201,7 +203,9 @@ void StoreLargestIntervals(
     DNALength curBoundary = 0, nextBoundary = 0;
     DNALength contigLength = ContigStartPos.Length(pos[cur].t);
     DNALength endOfCurrentInterval = curBoundary + contigLength;
-    (void)(curBoundary); (void)(nextBoundary); (void)(endOfCurrentInterval);
+    PB_UNUSED(curBoundary);
+    PB_UNUSED(nextBoundary);
+    PB_UNUSED(endOfCurrentInterval);
 
     curBoundary = ContigStartPos(pos[cur].t);
     nextBoundary = ContigStartPos(pos[next].t);  
@@ -213,7 +217,7 @@ void StoreLargestIntervals(
     //
 
     DNALength curIntervalLength = NumRemainingBases(pos[cur].q, intervalLength);
-    (void)(curIntervalLength);
+    PB_UNUSED(curIntervalLength);
 
     AdvanceIndexToPastInterval(pos, nPos, intervalLength, contigLength, ContigStartPos,
             cur, curBoundary, next, nextBoundary);
@@ -351,7 +355,7 @@ void StoreLargestIntervals(
             // just after where the interval starting at cur is, or the first
             // position in the next contig.
             //
-            int prevNext = next;
+            VectorIndex prevNext = next;
             AdvanceIndexToPastInterval(pos, nPos, intervalLength, contigLength, ContigStartPos,
                                        cur, curBoundary, next, nextBoundary);
             if (prevNext != next or recountInterval) {
@@ -621,7 +625,7 @@ int FastFindMaxIncreasingInterval(
         // Insert the interval into the interval queue maintaining only the 
         // top 'nBest' intervals. 
         //
-        WeightedIntervalSet::iterator lastIt = intervalQueue.begin();
+        //WeightedIntervalSet::iterator lastIt = intervalQueue.begin();
         MatchWeight lisWeight = MatchWeightFunction(lis);
         VectorIndex lisEnd = lis.size() - 1;
 
@@ -791,7 +795,7 @@ int ExhaustiveFindMaxIncreasingInterval(
         // top 'nBest' intervals. 
         //
 
-        WeightedIntervalSet::iterator lastIt = intervalQueue.begin();
+        //WeightedIntervalSet::iterator lastIt = intervalQueue.begin();
         MatchWeight lisWeight = MatchWeightFunction(lis);
         VectorIndex lisEnd = lis.size() - 1;
 

--- a/alignment/algorithms/anchoring/LongestIncreasingSubsequenceImpl.hpp
+++ b/alignment/algorithms/anchoring/LongestIncreasingSubsequenceImpl.hpp
@@ -1,5 +1,6 @@
 #ifndef _BLASR_LONGEST_INCREASING_SUBSEQUENCE_IMPL_HPP_
 #define _BLASR_LONGEST_INCREASING_SUBSEQUENCE_IMPL_HPP_
+#include "../../../pbdata/Types.h"
 
 using namespace std;
 
@@ -55,7 +56,8 @@ template<typename T, typename F_IntValue >
 int LongestIncreasingSubset(T *x, int xLength, vector<int> &subsetIndices, 
 	vector<int> &m, vector<int> &p, F_IntValue IntValue, 
 	int start, int end) {
-
+  PB_UNUSED(start);
+  PB_UNUSED(end);
 	//
 	// m[i] is the index of the LIS of length i+1
 	//
@@ -70,7 +72,7 @@ int LongestIncreasingSubset(T *x, int xLength, vector<int> &subsetIndices,
 	int maxM;
 	//  On the first iteration m[0] should be set to 0.
 	int lenM = 1;
-	int mi;
+	//int mi;
 
 	for (i = 0; i < xLength; i++) { 
 		//

--- a/alignment/bwt/BWT.hpp
+++ b/alignment/bwt/BWT.hpp
@@ -136,7 +136,7 @@ class Bwt {
 	}
 	
 	DNALength Locate(DNALength sp, DNALength ep, std::vector<DNALength> &positions, 
-        int maxCount = 0) {
+        DNALength maxCount = 0) {
 		DNALength bwtPos;
 		DNALength seqPos;
 		if (sp <= ep and (maxCount == 0 or ep - sp < maxCount)) {
@@ -150,7 +150,8 @@ class Bwt {
 	}
 
 	DNALength Locate(T_DNASequence &seq, std::vector<DNALength> &positions, 
-        int maxCount =0) {
+        DNALength maxCount =0) {
+    PB_UNUSED(maxCount);
 		DNALength ep, sp;
 		Count(seq, sp, ep);
 		return Locate(sp, ep, positions);

--- a/alignment/files/FragmentCCSIterator.cpp
+++ b/alignment/files/FragmentCCSIterator.cpp
@@ -38,7 +38,7 @@ Initialize(CCSSequence *_seqPtr, RegionTable *_regionTablePtr) {
     int i, j;
     for (i = 0; i < static_cast<int>(subreadIntervals.size()); i++) {
         for (j = 0; j < static_cast<int>(seqPtr->passStartBase.size()); j++) {
-            if (abs( subreadIntervals[i].start - seqPtr->passStartBase[j] ) < 10) {
+            if (abs( subreadIntervals[i].start - static_cast<int>(seqPtr->passStartBase[j]) ) < 10) {
                 readIntervalDirection[i] = seqPtr->passDirection[j];
                 break;
             }

--- a/alignment/format/SAMHeaderPrinter.cpp
+++ b/alignment/format/SAMHeaderPrinter.cpp
@@ -383,6 +383,7 @@ SAMHeaderRGs SAMHeaderPrinter::MakeRGs(const std::vector<std::string> & readsFil
 SAMHeaderPGs SAMHeaderPrinter::MakePGs(const std::vector<std::string> & readsFiles, 
         const std::string & progName, const std::string & progVersion, 
         const std::string & commandLine) {
+    PB_UNUSED(readsFiles);
     SAMHeaderPGs pgs;
 
     // program id, unique identifier for @PG lines;
@@ -416,6 +417,7 @@ SAMHeaderPGs SAMHeaderPrinter::MakePGs(const std::vector<std::string> & readsFil
 }
 
 SAMHeaderCOs SAMHeaderPrinter::MakeCOs(const std::vector<std::string> & readsFiles) {
+    PB_UNUSED(readsFiles);
     SAMHeaderCOs cos;
 
     if (fileType == FileType::PBBAM) {

--- a/alignment/format/SAMHeaderPrinter.hpp
+++ b/alignment/format/SAMHeaderPrinter.hpp
@@ -286,7 +286,7 @@ void SAMHeaderGroups<T>::Append(const std::vector<T> & groups) {
 template<class T>
 std::string SAMHeaderGroups<T>::ToString() {
     std::stringstream ss;
-    for (int i = 0; i < this->_groups.size(); i++) {
+    for (size_t i = 0; i < this->_groups.size(); i++) {
         ss << this->_groups[i] << std::endl;
     }
     return ss.str();

--- a/alignment/makefile
+++ b/alignment/makefile
@@ -4,7 +4,7 @@ THISDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 -include ${CURDIR}/defines.mk
 include ${THISDIR}/../rules.mk
 
-CXXOPTS  := -std=c++11 -pedantic -Wno-long-long -Wall -Wextra
+CXXOPTS  := -std=c++11 -pedantic -Wno-long-long -Wall -Wextra -Wno-overloaded-virtual
 SYSINCLUDES = ${HDF5_INC} ${PBBAM_INC} ${HTSLIB_INC} ${BOOST_INC}
 LIBS     += ${LIBPBDATA_LIB} ${LIBPBIHDF_LIB} ${HDF5_LIB} ${PBBAM_LIB} ${HTSLIB_LIB} ${ZLIB_LIB}
 LDFLAGS  += $(patsubst %,-L%,${LIBS})

--- a/alignment/statistics/StatUtilsImpl.hpp
+++ b/alignment/statistics/StatUtilsImpl.hpp
@@ -41,7 +41,7 @@ template<typename T>
 void MeanVar(std::vector<T> &values, float &mean, float &var) {
   T sum = 0;
   T sumsq = 0;
-  int i;
+  size_t i;
   if (values.size() == 0) {
     mean = 0; var = 0;
     return;

--- a/alignment/suffixarray/SuffixArray.hpp
+++ b/alignment/suffixarray/SuffixArray.hpp
@@ -164,6 +164,7 @@ public:
     }
 
     void PrintSuffices(T *target, int targetLength, int maxPrintLength) {
+        PB_UNUSED(targetLength);
         std::string seq;
         seq.resize(maxPrintLength+1);
         SAIndex i, s;
@@ -463,6 +464,7 @@ public:
     }
 
     void BuildSuffixArray(T* target, SAIndex targetLength, Sigma &alphabet) {
+        PB_UNUSED(alphabet);
         length = targetLength;
         assert(index == NULL or not deleteStructures);
         index  = ProtectedNew<SAIndex>(length);
@@ -506,6 +508,7 @@ public:
     }
 
     void WriteLCPTable(std::ofstream &out) {
+        PB_UNUSED(out);
         std::cout << "NOT YET IMPLEMENTED." << std::endl;
         exit(1);
     }
@@ -596,6 +599,7 @@ public:
     }
 
     void ReadLCPTable(std::ifstream &in) {
+        PB_UNUSED(in);
         std::cout <<" NOT YET IMPLEMENTED!!!" << std::endl;
         exit(1);
     }
@@ -641,6 +645,7 @@ public:
     }
 
     int SearchLCP(T* target, T* query, DNALength queryLength, SAIndex &low, SAIndex &high, DNALength &lcpLength, DNALength maxlcp) {
+      PB_UNUSED(maxlcp);
         //		cout << "searching lcp with query of length: " << queryLength << endl;
         lcpLength = 0;
         if (startPosTable != NULL and

--- a/alignment/tuples/DNATupleImpl.hpp
+++ b/alignment/tuples/DNATupleImpl.hpp
@@ -69,7 +69,7 @@ int SearchSequenceForTuple(Sequence &seq, TupleMetrics &tm, DNATuple &queryTuple
         while(curValidEnd < seq.length and IsACTG[seq.seq[curValidEnd]]) {
             curValidEnd++;
         }
-        if (curValidEnd - cur >= tm.tupleSize) {
+        if (curValidEnd - cur >= static_cast<DNALength>(tm.tupleSize)) {
             //
             // Found a span that does not have N's in it, 
             //
@@ -121,7 +121,7 @@ int SequenceToTupleList(Sequence &seq, TupleMetrics &tm, TupleList<DNATuple> &tu
         while(curValidEnd < seq.length and IsACTG[seq.seq[curValidEnd]]) {
             curValidEnd++;
         }
-        if (curValidEnd - cur >= tm.tupleSize) {
+        if (curValidEnd - cur >= static_cast<DNALength>(tm.tupleSize)) {
             //
             // Found a span that does not have N's in it, 
             //
@@ -172,7 +172,7 @@ int SequenceToTupleList(Sequence &seq, TupleMetrics &tm, TupleList<PositionDNATu
         while(curValidEnd < seq.length and IsACTG[seq.seq[curValidEnd]]) {
             curValidEnd++;
         }
-        if (curValidEnd - cur >= tm.tupleSize) {
+        if (curValidEnd - cur >= static_cast<DNALength>(tm.tupleSize)) {
             //
             // Found a span that does not have N's in it, 
             //

--- a/hdf/BufferedHDF2DArrayImpl.hpp
+++ b/hdf/BufferedHDF2DArrayImpl.hpp
@@ -149,6 +149,11 @@ void BufferedHDF2DArray<T>::Read(DSLength startX, DSLength endX, T*dest) {
  */
 template<typename T>
 void BufferedHDF2DArray<T>::Read(DSLength startX, DSLength endX, DSLength startY, DSLength endY, T* dest) {
+    (void)(startX);
+    (void)(endX);
+    (void)(startY);
+    (void)(endY);
+    (void)(dest);
     assert("ERROR, calling Read with an unsupported type. Use Read(startx,endx, starty,endy,datatype, dest) instead." == 0);
     exit(1);
 }
@@ -214,9 +219,10 @@ void BufferedHDF2DArray<T>::Create(H5::CommonFG *_container, string _datasetName
 }
 
 template<typename T>
-void BufferedHDF2DArray<T>::TypedCreate(H5::DataSpace &fileSpace, 
+void BufferedHDF2DArray<T>::TypedCreate(H5::DataSpace &fileSpace,
     H5::DSetCreatPropList &cparms) {
-
+    (void)(fileSpace);
+    (void)(cparms);
     assert("Error, calling HDF2DArray<T>::TypedCreate on an unsupported type.  A specialization must be written in HDF2DArray.h" == 0);
 }
 
@@ -224,7 +230,8 @@ void BufferedHDF2DArray<T>::TypedCreate(H5::DataSpace &fileSpace,
 template<typename T>
 void TypedWriteRow(const T*, const H5::DataSpace &memoryDataSpace, 
     const H5::DataSpace &fileDataSpace) {
-
+    (void)(memoryDataSpace);
+    (void)(fileDataSpace);
     assert("Error, calling HDF2DArray<T>::TypedWriteRow on an unsupported type.  A specialization must be written in HDF2DArray.h" == 0);
 }
 
@@ -253,7 +260,7 @@ void BufferedHDF2DArray<T>::WriteRow(const T *data, DSLength dataLength, DSLengt
         //
         bufferCapacity = (this->bufferSize / rowLength)*rowLength - this->bufferIndex;
         flushBuffer = false;
-        if (bufferCapacity  > dataLength - dataIndex) {
+        if (static_cast<long long>(bufferCapacity)  > static_cast<long long>(dataLength) - static_cast<long long>(dataIndex)) {
             bufferFillSize = dataLength - dataIndex;
         }
         else {
@@ -270,7 +277,7 @@ void BufferedHDF2DArray<T>::WriteRow(const T *data, DSLength dataLength, DSLengt
         //  When not appending, increment the position of where the data
         //  is to be written.
         //
-        if (destRow != -1) {
+        if (destRow != static_cast<DSLength>(-1)) {
             destRow += this->bufferIndex / rowLength;
         }
     }
@@ -312,7 +319,7 @@ void BufferedHDF2DArray<T>::Flush(DSLength destRow) {
         // will go, and how much to write.
         //
 
-        if (destRow == -1) {
+        if (destRow == static_cast<DSLength>(-1)) {
             fileArraySize[0] += numDataRows;
         }
         else {
@@ -343,7 +350,7 @@ void BufferedHDF2DArray<T>::Flush(DSLength destRow) {
         //
         // Determine which row to write to.
         //
-        if (destRow == -1) {
+        if (destRow == static_cast<DSLength>(-1)) {
             offset[0] = blockStart[0];
         }
         else {

--- a/hdf/BufferedHDFArrayImpl.hpp
+++ b/hdf/BufferedHDFArrayImpl.hpp
@@ -54,7 +54,7 @@ void BufferedHDFArray<T>::Write(const T *data, DSLength dataLength, bool append,
     while(dataIndex < dataLength) {
         bufferCapacity = this->bufferSize - this->bufferIndex;
         flushBuffer = false;
-        if (bufferCapacity  > dataLength - dataIndex) {
+        if (static_cast<long long>(bufferCapacity)  > static_cast<long long>(dataLength) - static_cast<long long>(dataIndex)) {
             bufferFillSize = dataLength - dataIndex;
         }
         else {
@@ -162,14 +162,17 @@ void BufferedHDFArray<T>::TypedWrite(const char **data, const H5::DataSpace &mem
 template<typename T>
 void BufferedHDFArray<T>::TypedWrite(const T* data, const H5::DataSpace &memorySpace, 
     const H5::DataSpace &extendedSpace) {
-
+    (void)(data);
+    (void)(memorySpace);
+    (void)(extendedSpace);
     assert("Calling TypedWrite on an unsupported type" == 0);
 }
 
 template<typename T>
 void BufferedHDFArray<T>::TypedCreate(H5::DataSpace &fileSpace, 
     H5::DSetCreatPropList &cparms) {
-
+    (void)(fileSpace);
+    (void)(cparms);
     std::cout << "DEFAULT typed create " << std::endl;
 }
 
@@ -398,6 +401,7 @@ void BufferedHDFArray<T>::Read(DSLength start, DSLength end, T* dest) {
 
 template<typename T>
 void BufferedHDFArray<T>::ReadDataset(std::vector<T> &dest) {
+    (void)(dest);
     assert("ERROR, calling ReadDataset with an unsupported type.");
     exit(1); // this is in case the assert statement is removed.
 }

--- a/hdf/HDFArray.hpp
+++ b/hdf/HDFArray.hpp
@@ -73,7 +73,7 @@ public:
 
 class HDFStringArray: public HDFArray<std::string> {
 public:
-    void Read(UInt start, UInt end, std::string* dest) {
+    void Read(DSLength start, DSLength end, std::string* dest) {
         std::vector<char*> tmpDestCharPtrs;
         if (end == start) return;
         assert(end > start);

--- a/hdf/HDFRegionsWriter.cpp
+++ b/hdf/HDFRegionsWriter.cpp
@@ -46,8 +46,10 @@ bool HDFRegionsWriter::Write(const RegionAnnotation &annotation) {
         regionsArray_.WriteRow(annotation.row, HDFRegionsWriter::NCOLS);
     }
     catch (H5::Exception &e) {
-        AddErrorMessage("Failed to write region annotation " + 
-                annotation.GetHoleNumber());
+        std::ostringstream sout;
+        sout << "Failed to write region annotation "
+             << annotation.GetHoleNumber();
+        AddErrorMessage(sout.str());
         return false;
     }
     ++curRow_;

--- a/hdf/HDFWriteBuffer.hpp
+++ b/hdf/HDFWriteBuffer.hpp
@@ -9,7 +9,7 @@ class HDFWriteBuffer {
 public:
     T         *writeBuffer;
     int       bufferIndex;
-    int       bufferSize;
+    DSLength       bufferSize;
 
     HDFWriteBuffer() {
         writeBuffer = NULL;

--- a/hdf/HDFWriterBase.hpp
+++ b/hdf/HDFWriterBase.hpp
@@ -125,7 +125,7 @@ bool __WriteFakeDataSet(HDFGroup & dsGroup, const std::string & dsName,
 ///        with value 'fillData'
 template<typename T>
 bool __WriteFake2DDataSet(HDFGroup & dsGroup, const std::string & dsName,
-                           const uint32_t rowNum, const int colNum, const T & fillData) {
+                           const uint32_t rowNum, const size_t colNum, const T & fillData) {
     BufferedHDF2DArray<T> dsArray;
     if (dsArray.Initialize(dsGroup, dsName, colNum) == 0) return false;
     T * data = new T[colNum];

--- a/hdf/makefile
+++ b/hdf/makefile
@@ -4,7 +4,7 @@ THISDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 -include ${CURDIR}/defines.mk
 include ${THISDIR}/../rules.mk
 
-CXXOPTS  += -std=c++11 -pedantic -Wall -Wextra
+CXXOPTS  += -std=c++11 -pedantic -Wall -Wextra -Wno-overloaded-virtual
 SYSINCLUDES = ${HDF5_INC} ${PBBAM_INC} ${HTSLIB_INC} ${BOOST_INC}
 LIBS     += ${LIBPBDATA_LIB} ${HDF5_LIB} ${PBBAM_LIB} ${HTSLIB_LIB} ${ZLIB_LIB}
 LDFLAGS  += $(patsubst %,-L%,${LIBS})

--- a/pbdata/CompressedSequenceImpl.hpp
+++ b/pbdata/CompressedSequenceImpl.hpp
@@ -163,6 +163,7 @@ int CompressedSequence<T_Sequence>::BuildFourBitReverseIndex(int binSize) {
 
 template<typename T_Sequence>
 int CompressedSequence<T_Sequence>::BuildReverseIndex(int maxRun, int binSize) {
+    PB_UNUSED(binSize);
     hasIndex = 1;
 
     DNALength i;

--- a/pbdata/FASTQSequence.cpp
+++ b/pbdata/FASTQSequence.cpp
@@ -351,7 +351,7 @@ void FASTQSequence::PrintFastqQuality(ostream &out, int lineLength) const {
 
 bool FASTQSequence::GetQVs(const QVIndex & qvIndex, std::vector<uint8_t> & qvs, bool reverse) const {
     qvs.clear();
-    uint8_t *  qualPtr;
+    uint8_t *  qualPtr= nullptr;
     int charOffset = charToQuality;
     if (qvIndex == I_QualityValue) {
         qualPtr = qual.data;

--- a/pbdata/Types.h
+++ b/pbdata/Types.h
@@ -23,4 +23,7 @@ typedef uint8_t  Byte;
 typedef uint8_t  UChar;
 typedef uint16_t HalfWord;
 typedef float MatchWeight;
+
+#define PB_UNUSED(VAR) (void)(VAR)
+
 #endif // _BLASR_TYPES_H_

--- a/pbdata/matrix/MatrixImpl.hpp
+++ b/pbdata/matrix/MatrixImpl.hpp
@@ -9,7 +9,7 @@
 #include "../Types.h"
 
 template<typename T>
-void CreateMatrix(int rows, int cols, std::vector<T*> matrix) {
+void CreateMatrix(VectorIndex rows, int cols, std::vector<T*> matrix) {
 	matrix.resize(rows);
     if (matrix[0]) {delete [] matrix[0]; matrix[0] = NULL;}
 	matrix[0] = ProtectedNew<T>(rows*cols);

--- a/pbdata/metagenome/SequenceIndexDatabaseImpl.hpp
+++ b/pbdata/metagenome/SequenceIndexDatabaseImpl.hpp
@@ -250,7 +250,7 @@ template<typename TSeq>
 VectorIndex SequenceIndexDatabase<TSeq>::
 AddSequence(TSeq &sequence) {
     int endPos = growableSeqStartPos[growableSeqStartPos.size() - 1];
-    int growableSize = growableSeqStartPos.size();
+    //int growableSize = growableSeqStartPos.size();
     growableSeqStartPos.push_back(endPos + sequence.length + 1);
     std::string fastaTitle;
     sequence.GetFASTATitle(fastaTitle);
@@ -269,7 +269,7 @@ Finalize() {
     assert(names==NULL);
     names = ProtectedNew<char*>(nSeq);
     deleteNames = true;
-    unsigned int i;
+    int i;
     if (nameLengths) {delete [] nameLengths; nameLengths = NULL;}
     nameLengths = ProtectedNew<int>(nSeq);
     deleteNameLengths = true;

--- a/pbdata/sam/SAMAlignment.cpp
+++ b/pbdata/sam/SAMAlignment.cpp
@@ -48,7 +48,7 @@ bool SAMAlignment::StoreValues(std::string &line,  int lineNumber) {
   //
   // Define a temporary mapqv value that gets over a GMAP bug that prints a mapqv < 0.
   //
-  int tmpMapQV;
+  int tmpMapQV = 0;
   if (!(strm >> qName)) {
     parseError = true;
     field = S_QNAME;


### PR DESCRIPTION
Also, this suppresses some warnings for hidden virtual methods, but those might actually be errors! So somebody should drop `-Wno-overloaded-virtual` and address those.

I've also added the `PB_UNUSED()` macro, to make it easier to find unused variables (in case anybody wants to fix these for reals).