### PR TITLE
either declare `i` unsigned int or this patch

### DIFF
--- a/alignment/format/SAMHeaderPrinter.hpp
+++ b/alignment/format/SAMHeaderPrinter.hpp
@@ -278,7 +278,7 @@ void SAMHeaderGroups<T>::Add(const T & group) {
 
 template<class T>
 void SAMHeaderGroups<T>::Append(const std::vector<T> & groups) {
-    for(int i = 0; i < groups.size(); i++) {
+    for(int i = 0; i < int(groups.size()); i++) {
         this->Add(groups[i]);
     }
 }


### PR DESCRIPTION
```
In file included from format/SAMHeaderPrinter.cpp:2:0:
format/SAMHeaderPrinter.hpp: In instantiation of ‘void SAMHeaderGroups<T>::Append(const std::vector<T_Value>&) [with T = std::basic_string<char>]’:
format/SAMHeaderPrinter.cpp:441:44:   required from here
format/SAMHeaderPrinter.hpp:281:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for(int i = 0; i < groups.size(); i++) {
                      ^
```