### PR TITLE
Added missing headers

### DIFF
--- a/alignment/algorithms/alignment/ExtendAlign.hpp
+++ b/alignment/algorithms/alignment/ExtendAlign.hpp
@@ -1,6 +1,6 @@
 #ifndef _BLASR_EXTEND_ALIGN_HPP_
 #define _BLASR_EXTEND_ALIGN_HPP_
-
+#include <iosfwd>
 #include <vector>
 #include <algorithm>
 // pbdata

--- a/alignment/algorithms/alignment/KBandAlign.hpp
+++ b/alignment/algorithms/alignment/KBandAlign.hpp
@@ -1,6 +1,6 @@
 #ifndef _BLASR_K_BAND_ALIGN_HPP_
 #define _BLASR_K_BAND_ALIGN_HPP_
-
+#include <iosfwd>
 #include <algorithm>
 #include <vector>
 #include <limits.h>


### PR DESCRIPTION
added ```#include <iosfwd>```.
This resolves the issue where ```make build-submodule`` was error out with g++6.0