### PR TITLE
Show actual flag in error messages

### DIFF
--- a/pbdata/CommandLineParser.cpp
+++ b/pbdata/CommandLineParser.cpp
@@ -290,7 +290,7 @@ ParseCommandLine(int argc, char* argv[],
             }
             if (ev != CLGood) {
                 PrintUsage();
-                PrintErrorMessage(ev, &argv[argi][1]);
+                PrintErrorMessage(ev, &argv[argi][0]);
                 exit(1);
             }
         }
@@ -310,7 +310,7 @@ ParseCommandLine(int argc, char* argv[],
     ev = PrintErrorOnMissingOptions();
     if (ev != CLGood) {
         PrintUsage();
-        PrintErrorMessage(ev, &argv[argi][1]);
+        PrintErrorMessage(ev, &argv[argi][0]);
         exit(1);
     }
     return 1;


### PR DESCRIPTION
This would have avoided some confusion in
  PacificBiosciences/blasr#245

Without this change:
```
$ blasr --woo
...
ERROR: -woo is not a valid option.
```

With this change:
```
$ blasr --woo
...
ERROR: --woo is not a valid option.
```