### PR TITLE
Avoid trailing slash in UNIX find arg

### DIFF
--- a/alignment/makefile
+++ b/alignment/makefile
@@ -25,7 +25,9 @@ paths := . simulator format files utils tuples statistics qvs suffixarray \
 	algorithms/alignment algorithms/alignment/sdp algorithms/anchoring algorithms/compare algorithms/sorting \
 	query
 paths := ${paths} $(patsubst %,${THISDIR}%,${paths})
-sources := $(shell find ${THISDIR} -name '*.cpp')
+# Avoid trailing slash, since OSX find keeps it.
+THISDIRX := $(patsubst %/,%,${THISDIR})
+sources := $(shell find ${THISDIRX} -name '*.cpp')
 
 ifdef nohdf
 sources := $(filter-out ${THISDIR}files/% ${THISDIR}utils/FileOfFileNames.cpp ${THISDIR}format/SAMHeaderPrinter.cpp, $(sources))

--- a/pbdata/makefile
+++ b/pbdata/makefile
@@ -17,7 +17,9 @@ shared: libpbdata${SH_LIB_EXT}
 
 paths := . matrix reads metagenome qvs saf utils loadpulses alignment amos sam
 paths := ${paths} $(patsubst %,${THISDIR}%,${paths})
-sources := $(shell find ${THISDIR} -name '*.cpp')
+# Avoid trailing slash, since OSX find keeps it.
+THISDIRX := $(patsubst %/,%,${THISDIR})
+sources := $(shell find ${THISDIRX} -name '*.cpp')
 sources := $(notdir ${sources})
 objects := $(sources:.cpp=.o)
 shared_objects := $(sources:.cpp=.shared.o)


### PR DESCRIPTION
UNIX `find` works differently on OSX, where it keeps any trailing slash
on its directory argument.

fixes PacificBiosciences/pbdagcon#59

(This is on the new `pbdagcon` branch because there are a lot of changes that are not yet used in pbdagcon. Someone will have to integrate this fix later, if still needed.)